### PR TITLE
fix: 修复 articleSort 设置文章封面逻辑不一致的问题

### DIFF
--- a/layout/includes/mixins/article-sort.pug
+++ b/layout/includes/mixins/article-sort.pug
@@ -11,7 +11,7 @@ mixin articleSort(posts)
         if article.cover && theme.cover.archives_enable
           .article-sort-img
             a.article-sort-item__img(href=url_for(article.path))
-              img(src=article.cover alt=article.title || 'No Title' onerror=`this.onerror=null;this.src='`+ url_for(theme.lodding_bg.post_page) + `'`)
+              img(src=`${article.cover}` alt=article.title || 'No Title' onerror=`this.onerror=null;this.src='`+ url_for(theme.lodding_bg.post_page) + `'`)
         .article-sort-post
           a.article-sort-item__post(href=url_for(article.path))
             i.fa.fa-clock-o(aria-hidden="true")


### PR DESCRIPTION

article 模板中设置文章封面的逻辑和 index 页面最近文章 [L31](https://github.com/jerryc127/hexo-theme-butterfly/blob/dev/layout/includes/mixins/post-ui.pug#L13)，不一致。

因此，当 post cover 设置如下时

```yaml
cover
  - img_url

```
index 页可以正常渲染，而 article 中 `src` 实际上被传入了一个数组，因此无法正确读取图片 url。

修改 articleSort 逻辑保证两处渲染逻辑一致

