### PR TITLE
修復 comments.use 不能爲空的 bug

### DIFF
--- a/layout/includes/third-party/pjax.pug
+++ b/layout/includes/third-party/pjax.pug
@@ -10,7 +10,7 @@ script.
     '.js-pjax'
   ]
 
-  if (!{theme.Open_Graph_meta && theme.comments.use.includes('Livere')}) {
+  if (!{theme.Open_Graph_meta && theme.comments.use && theme.comments.use.includes('Livere')}) {
     pjaxSelectors.unshift('meta[property="og:image"]', 'meta[property="og:title"]', 'meta[property="og:url"]')
   }
 


### PR DESCRIPTION
修復 comments.use 不能爲空的 bug

似乎是由於 修復了 issue #294 而產生的