### PR TITLE
Add a flag for allowing to disable aside.card_author.button

### DIFF
--- a/layout/includes/widget/card_author.pug
+++ b/layout/includes/widget/card_author.pug
@@ -27,9 +27,10 @@
             .headline= _p('aside.categories') 
             .length_num= site.categories.length
 
-    a#card-info-btn.button--animated(href=theme.aside.card_author.button.link)
-      i(class=theme.aside.card_author.button.icon)
-      span=theme.aside.card_author.button.text
+    if theme.aside.card_author.button.enable
+      a#card-info-btn.button--animated(href=theme.aside.card_author.button.link)
+        i(class=theme.aside.card_author.button.icon)
+        span=theme.aside.card_author.button.text
   
     if(theme.social)
         .card-info-social-icons.is-center


### PR DESCRIPTION
There has been a button for the page of my github and I don't have other pages can be linked. So I want to hide the button in the author card and make it clearer. Maybe it is useful for other ones.