### PR TITLE
fix multi-site_verification

### DIFF
--- a/layout/includes/head/site_verification.pug
+++ b/layout/includes/head/site_verification.pug
@@ -1,14 +1,34 @@
 if theme.google_site_verification
-  meta(name="google-site-verification" content=theme.google_site_verification)
+  if theme.google_site_verification instanceof Array
+    each val in theme.google_site_verification
+      meta(name="google-site-verification" content=val)
+  else
+    meta(name="google-site-verification" content=theme.google_site_verification)
 
 if theme.bing_site_verification
-  meta(name="msvalidate.01" content=theme.bing_site_verification)
+  if theme.bing_site_verification instanceof Array
+    each val in theme.bing_site_verification
+      meta(name="msvalidate.01" content=val)
+  else
+    meta(name="msvalidate.01" content=theme.bing_site_verification)
 
 if theme.baidu_site_verification
-  meta(name="baidu-site-verification" content=theme.baidu_site_verification)
+  if theme.baidu_site_verification instanceof Array
+    each val in theme.baidu_site_verification
+      meta(name="baidu-site-verification" content=val)
+  else
+    meta(name="baidu-site-verification" content=theme.baidu_site_verification)
 
 if theme.qihu_site_verification
-  meta(name="360-site-verification" content=theme.qihu_site_verification)
+  if theme.qihu_site_verification instanceof Array
+    each val in theme.qihu_site_verification
+      meta(name="360-site-verification" content=val)
+  else
+    meta(name="360-site-verification" content=theme.qihu_site_verification)
 
 if theme.yandex_site_verification
-  meta(name="yandex-verification" content=theme.yandex_site_verification)
+  if theme.yandex_site_verification instanceof Array
+    each val in theme.yandex_site_verification
+      meta(name="yandex-verification" content=val)
+  else
+    meta(name="yandex-verification" content=theme.yandex_site_verification)


### PR DESCRIPTION
# 增添验证逻辑,兼容多站点验证
- 修改前这样的多标签验证会以数组方式添加至meta,搜索引擎会存在识别问题
```yml
baidu_site_verification:
  - code-A
  - code-B
  - code-C
```

- 他们需要的是单标签
![QQ截图20210214190030](https://user-images.githubusercontent.com/61131704/107875073-c6baae80-6ef8-11eb-840a-0808733fafaf.jpg)

- 修改后兼容各种杂乱写法
![QQ截图20210214190547](https://user-images.githubusercontent.com/61131704/107875085-db974200-6ef8-11eb-9d4d-497f2cfb4fba.jpg)


