### PR TITLE
修复文章页无法显示标签

### DIFF
--- a/layout/includes/header/post-info.pug
+++ b/layout/includes/header/post-info.pug
@@ -35,6 +35,16 @@
             a(href=url_for(item.path)).post-meta-categories #[=item.name]
             if (index < page.categories.data.length - 1)
               i.fas.fa-angle-right.post-meta-separator
+      
+      //- add
+      if (theme.post_meta.page.tags && page.tags.data.length > 0)
+        span.post-meta-categories
+          span.post-meta-separator |
+          i.fas.fa-tag
+          each item, index in page.tags.data
+            a(href=url_for(item.path)).article-meta__tags #[=item.name]
+            if (index < page.tags.data.length - 1)
+              span.article-meta__link #[='•']
 
     .meta-secondline
       - let postWordcount = theme.wordcount.enable && (theme.wordcount.post_wordcount || theme.wordcount.min2read)


### PR DESCRIPTION
在主题的3.7.8版本中，即使将主题配置文件中如下tags设置为true，依然没有显示标签

```
post_meta:
  post:
    tags: true # true or false 文章頁是否顯示標籤
```
检查后发现是缺少对应代码，已经添加，最终的效果可以参考我的博客：
https://doraemonzzz.com/2018/07/01/%E6%9C%BA%E5%99%A8%E5%AD%A6%E4%B9%A0%E4%BB%A5%E5%8F%8A%E8%AE%A1%E7%AE%97%E6%9C%BA%E5%85%AC%E5%BC%80%E8%AF%BE%E6%B1%87%E6%80%BB%E5%B8%96/