### PR TITLE
fix: 修复友情链接的头像带有灯箱的问题

### DIFF
--- a/source/js/main.js
+++ b/source/js/main.js
@@ -305,7 +305,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   const jqLoadAndRun = () => {
     const $fancyboxEle = GLOBAL_CONFIG.lightbox === 'fancybox'
-      ? document.querySelectorAll('#article-container :not(a):not(.gallery-group) > img, #article-container > img')
+      ? document.querySelectorAll('#article-container :not(a):not(.gallery-group):not(.flink-item-icon) > img, #article-container > img')
       : []
     const fbLengthNoZero = $fancyboxEle.length > 0
     const $jgEle = document.querySelectorAll('#article-container .justified-gallery')

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -294,7 +294,7 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   const addMediumZoom = () => {
-    const zoom = mediumZoom(document.querySelectorAll('#article-container :not(a)>img'))
+    const zoom = mediumZoom(document.querySelectorAll('#article-container :not(a):not(.flink-item-icon) > img'))
     zoom.on('open', e => {
       const photoBg = document.documentElement.getAttribute('data-theme') === 'dark' ? '#121212' : '#fff'
       zoom.update({


### PR DESCRIPTION
增加了对图片附加灯箱时，需要排除的 `class`。

使用 `npm i Android-KitKat/hexo-theme-butterfly#fix-flink` 进行测试。

相关代码:
https://github.com/jerryc127/hexo-theme-butterfly/blob/026a348482d611f34ef5e70e759e7f71528160f4/layout/includes/page/flink.pug#L15-L17

## 问题截图
![友情链接的头像带有灯箱的问题](https://user-images.githubusercontent.com/6592315/124392446-3c98a880-dd28-11eb-9bb7-d742a63d6a1d.png)
