### PR TITLE
fix: 文章 post-info 中发表时间或更新时间 title 属性 undefined 问题

### DIFF
--- a/layout/includes/header/post-info.pug
+++ b/layout/includes/header/post-info.pug
@@ -21,9 +21,9 @@
             - let data_type_update = theme.post_meta.post.date_type === 'updated'
             - let date_type = data_type_update ? 'updated' : 'date'
             - let date_icon = data_type_update ? 'fas fa-history' :'far fa-calendar-alt'
-            - let data_info = data_type_update ? _p('post.updated') : _p('post.created')
+            - let date_title = data_type_update ? _p('post.updated') : _p('post.created')
             i.fa-fw.post-meta-icon(class=date_icon)
-            span.post-meta-label= data_info
+            span.post-meta-label= date_title
             time(datetime=date_xml(page[date_type]) title=date_title + ' ' + full_date(page[date_type]))=date(page[date_type], config.date_format)
       if (theme.post_meta.post.categories && page.categories.data.length > 0)
         span.post-meta-categories


### PR DESCRIPTION
当在配置文件 post_meta --> post --> date_type 选择 created 或者 updated 时，会出现 title 属性中 “发表于” 或 “更新于” undefined
![image](https://user-images.githubusercontent.com/53698089/129147205-79bf1631-8e56-4cf9-9b33-a9c941aed0d9.png)
