### PR TITLE
fix: 捐赠码非空判断

### DIFF
--- a/layout/includes/post/reward.pug
+++ b/layout/includes/post/reward.pug
@@ -4,10 +4,11 @@
     = ' ' + _p('donate')
   .reward-main
     ul.reward-all
-      each item in theme.reward.QR_code
-        - var clickTo = item.link ? item.link : item.img
-        li.reward-item
-          a(href=url_for(clickTo) target='_blank')
-            img.post-qr-code-img(src=url_for(item.img) alt=item.text)
-          .post-qr-code-desc=item.text
+      if theme.reward.QR_code
+        each item in theme.reward.QR_code
+          - var clickTo = item.link ? item.link : item.img
+          li.reward-item
+            a(href=url_for(clickTo) target='_blank')
+              img.post-qr-code-img(src=url_for(item.img) alt=item.text)
+            .post-qr-code-desc=item.text
 


### PR DESCRIPTION
在theme.reward.enable开启下，但是并没有添加捐赠二维码的，进行编译(hexo g)出现null错误。进行简单的判空，对新手小白用户比较友好