### PR TITLE
新增 head 标签内 theme-color 的配置项

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -470,6 +470,8 @@ site_verification:
 #   blockquote_padding_color: "#49b1f5"
 #   blockquote_background_color: "#49b1f5"
 #   scrollbar_color: "#49b1f5"
+#   meta_theme_color_light: "ffffff"
+#   meta_theme_color_dark: "#0d0d0d"
 
 # The top_img settings of home page
 # default: top img - full screen, site info - middle (默認top_img全屏，site_info在中間)

--- a/layout/includes/head.pug
+++ b/layout/includes/head.pug
@@ -16,7 +16,9 @@
 - else pageKeywords = Array.isArray(config.keywords) ? (config.keywords).join(','):  ([]).join(',') || config.keywords
 - var pageAuthor = config.email ? config.author + ',' + config.email : config.author
 - var pageCopyright = config.copyright || config.author
-- var themeColor = theme.display_mode === 'dark' ? theme.theme_color.meta_theme_color_dark : theme.theme_color.meta_theme_color_light
+- var themeColorLight = theme.theme_color && theme.theme_color.enable && theme.theme_color.meta_theme_color_light || '#ffffff'
+- var themeColorDark = theme.theme_color && theme.theme_color.enable && theme.theme_color.meta_theme_color_dark || '#0d0d0d'
+- var themeColor = theme.display_mode === 'dark' ? themeColorDark : themeColorLight
 
 meta(charset='UTF-8')
 meta(http-equiv="X-UA-Compatible" content="IE=edge")

--- a/layout/includes/head.pug
+++ b/layout/includes/head.pug
@@ -16,7 +16,7 @@
 - else pageKeywords = Array.isArray(config.keywords) ? (config.keywords).join(','):  ([]).join(',') || config.keywords
 - var pageAuthor = config.email ? config.author + ',' + config.email : config.author
 - var pageCopyright = config.copyright || config.author
-- var themeColor = theme.display_mode === 'dark' ? '#0d0d0d' : '#ffffff'
+- var themeColor = theme.display_mode === 'dark' ? theme.theme_color.meta_theme_color_dark : theme.theme_color.meta_theme_color_light
 
 meta(charset='UTF-8')
 meta(http-equiv="X-UA-Compatible" content="IE=edge")

--- a/scripts/helpers/inject_head_js.js
+++ b/scripts/helpers/inject_head_js.js
@@ -8,6 +8,8 @@
 hexo.extend.helper.register('inject_head_js', function () {
   const { darkmode, aside } = this.theme
 
+  const { theme_color } = hexo.theme.config
+
   const localStore = `
     win.saveToLocal = {
       set: function setWithExpiry(key, value, ttl) {
@@ -62,13 +64,13 @@ hexo.extend.helper.register('inject_head_js', function () {
       win.activateDarkMode = function () {
         document.documentElement.setAttribute('data-theme', 'dark')
         if (document.querySelector('meta[name="theme-color"]') !== null) {
-          document.querySelector('meta[name="theme-color"]').setAttribute('content', '#0d0d0d')
+          document.querySelector('meta[name="theme-color"]').setAttribute('content', '${theme_color.meta_theme_color_dark}')
         }
       }
       win.activateLightMode = function () {
         document.documentElement.setAttribute('data-theme', 'light')
         if (document.querySelector('meta[name="theme-color"]') !== null) {
-          document.querySelector('meta[name="theme-color"]').setAttribute('content', '#ffffff')
+          document.querySelector('meta[name="theme-color"]').setAttribute('content', '${theme_color.meta_theme_color_light}')
         }
       }
       const t = saveToLocal.get('theme')

--- a/scripts/helpers/inject_head_js.js
+++ b/scripts/helpers/inject_head_js.js
@@ -9,6 +9,8 @@ hexo.extend.helper.register('inject_head_js', function () {
   const { darkmode, aside } = this.theme
 
   const { theme_color } = hexo.theme.config
+  const themeColorLight = theme_color && theme_color.enable && theme_color.meta_theme_color_light || '#ffffff'
+  const themeColorDark = theme_color && theme_color.enable && theme_color.meta_theme_color_dark || '#0d0d0d'
 
   const localStore = `
     win.saveToLocal = {
@@ -64,13 +66,13 @@ hexo.extend.helper.register('inject_head_js', function () {
       win.activateDarkMode = function () {
         document.documentElement.setAttribute('data-theme', 'dark')
         if (document.querySelector('meta[name="theme-color"]') !== null) {
-          document.querySelector('meta[name="theme-color"]').setAttribute('content', '${theme_color.meta_theme_color_dark}')
+          document.querySelector('meta[name="theme-color"]').setAttribute('content', '${themeColorDark}')
         }
       }
       win.activateLightMode = function () {
         document.documentElement.setAttribute('data-theme', 'light')
         if (document.querySelector('meta[name="theme-color"]') !== null) {
-          document.querySelector('meta[name="theme-color"]').setAttribute('content', '${theme_color.meta_theme_color_light}')
+          document.querySelector('meta[name="theme-color"]').setAttribute('content', '${themeColorLight}')
         }
       }
       const t = saveToLocal.get('theme')


### PR DESCRIPTION
实现对 safari 15 顶部状态栏颜色的修改

![theme-color](https://user-images.githubusercontent.com/50760230/155713589-cb952047-617d-4d3d-b356-a502f5c462bf.jpg)
