### PR TITLE
fix: 标题中带有 HTML 关键字时，会破坏相关推荐的渲染。

### DIFF
--- a/scripts/helpers/related_post.js
+++ b/scripts/helpers/related_post.js
@@ -54,14 +54,14 @@ hexo.extend.helper.register('related_posts', function (currentPost, allPosts) {
         relatedPosts[i].cover === false
           ? relatedPosts[i].randomcover
           : relatedPosts[i].cover
-      result += `<div><a href="${this.url_for(relatedPosts[i].path)}" title="${relatedPosts[i].title}">`
+      result += `<div><a href="${this.url_for(relatedPosts[i].path)}" title="${this.escape_html(relatedPosts[i].title)}">`
       result += `<img class="cover" src="${this.url_for(cover)}" alt="cover">`
       if (dateType === 'created') {
         result += `<div class="content is-center"><div class="date"><i class="far fa-calendar-alt fa-fw"></i> ${this.date(relatedPosts[i].created, hexoConfig.date_format)}</div>`
       } else {
         result += `<div class="content is-center"><div class="date"><i class="fas fa-history fa-fw"></i> ${this.date(relatedPosts[i].updated, hexoConfig.date_format)}</div>`
       }
-      result += `<div class="title">${relatedPosts[i].title}</div>`
+      result += `<div class="title">${this.escape_html(relatedPosts[i].title)}</div>`
       result += '</div></a></div>'
     }
 


### PR DESCRIPTION
例如标题带有 `"`、`<`、`>` 等字符时，文章底部相关推荐的渲染会发生错误。

该提交使用了 `escape_html` 辅助函数，此特性于 hexojs/hexo#4581 增加。
也就是说，无法在 [hexo@5.3.0](https://github.com/hexojs/hexo/releases/tag/5.3.0) 以下版本运行。