### PR TITLE
fix algolia search cutContent

### DIFF
--- a/source/js/search/algolia.js
+++ b/source/js/search/algolia.js
@@ -95,7 +95,7 @@ window.addEventListener('load', () => {
           <a href="${link}" class="algolia-hit-item-link">
           ${data._highlightResult.title.value || 'no-title'}
           </a>
-          <p class="algolia-hit-item-content">${cutContent(data._highlightResult.contentStripTruncate.value)}</p>`
+          <p class="algolia-hit-item-content">${cutContent(data._highlightResult.contentStrip.value)}</p>`
       },
       empty: function (data) {
         return (


### PR DESCRIPTION
参数用法为：`content:strip:truncate,0,200`，意为去除html标记，从0开始至第200个字符截断，舍弃后续内容，故无需配置此参数，否则将报错
正确配置应为：`content:strip`
同时因`hexo-algolia`不提供全文输出配置，故文档也应同步更改为必须使用[`hexo-algoliasearch`](https://github.com/LouisBarranqueiro/hexo-algoliasearch#readme)插件并作相应配置说明至少需要配置三类索引
```
algolia:
  fields:
    - path（或permalink）
    - title
    - content:strip
```