### PR TITLE
Update local-search.js

### DIFF
--- a/source/js/search/local-search.js
+++ b/source/js/search/local-search.js
@@ -2,11 +2,12 @@ window.addEventListener('load', () => {
   let loadFlag = false
   let dataObj = []
   const $searchMask = document.getElementById('search-mask')
+  const bodyStyle = document.body.style
 
   const openSearch = () => {
-    const bodyStyle = document.body.style
     bodyStyle.width = '100%'
     bodyStyle.overflow = 'hidden'
+    bodyStyle.paddingRight = '8px'
     btf.animateIn($searchMask, 'to_show 0.5s')
     btf.animateIn(document.querySelector('#local-search .search-dialog'), 'titleScale 0.5s')
     setTimeout(() => { document.querySelector('#local-search-input input').focus() }, 100)
@@ -24,9 +25,9 @@ window.addEventListener('load', () => {
   }
 
   const closeSearch = () => {
-    const bodyStyle = document.body.style
     bodyStyle.width = ''
     bodyStyle.overflow = ''
+    bodyStyle.paddingRight = ''
     btf.animateOut(document.querySelector('#local-search .search-dialog'), 'search_close .5s')
     btf.animateOut($searchMask, 'to_hide 0.5s')
   }


### PR DESCRIPTION
通过给`body`添加`padding-right`补偿因为隐藏滚动条右边失去的一小段距离 (可以消除页面因此产生的抖动

> 原理和`fancybox`这一样，但是这方法对主题中`nav-visible`状态下的`#nav`和`rightside`不管用，要是大佬能优化下这两个就更好了

![4{VF 8SN}4(HNY61VS2QS$7](https://user-images.githubusercontent.com/53534938/169023431-afe302f6-21a5-4e4c-ac49-30f0e6280052.png)
