### PR TITLE
Feat: 添加系列文章目录

### DIFF
--- a/layout/includes/head/config_site.pug
+++ b/layout/includes/head/config_site.pug
@@ -6,6 +6,9 @@
   else if (page.highlight_shrink === true || page.highlight_shrink === false) isHighlightShrink = page.highlight_shrink
   else isHighlightShrink = theme.highlight_shrink
 
+  if (page.series)
+    var Series = page.series
+
   var showToc = false
   if (theme.aside.enable && page.aside !== false) {
     let tocEnable = false

--- a/layout/includes/widget/card_series_post.pug
+++ b/layout/includes/widget/card_series_post.pug
@@ -1,0 +1,15 @@
+.card-widget(class='series_post' id='series_post')
+  .item-headline
+    i(class='fas fa-car-side')
+    span 系列文章 #{Series}
+  .item-content
+    - let list = site.posts.sort('date', -1)
+    ul(class='series_post_list')
+      - list.each(function(article){
+        if article.series == Series
+          - let link = article.link || article.path
+          - let title = article.title || _p('no_title')
+          li
+            a.title(href=url_for(link) title=title)= title
+      - })
+

--- a/layout/includes/widget/index.pug
+++ b/layout/includes/widget/index.pug
@@ -13,6 +13,8 @@
       .sticky_layout
         if showToc
           include ./card_post_toc.pug
+        if Series
+          include ./card_series_post.pug
         !=partial('includes/widget/card_recent_post', {}, {cache: true})
         !=partial('includes/widget/card_ad', {}, {cache: true})
   else


### PR DESCRIPTION
我看了一下pug代码，增加了系列文章目录功能，只要文章头有serises属性就会自动在侧边栏添加
![image](https://user-images.githubusercontent.com/60124215/169496327-86859342-dfe7-4534-b63f-54b466e17e9e.png)
这是我博客的效果https://blog.qsgy.tk/