### PR TITLE
change:调整not-top-img的background以去掉黑玻璃效果

### DIFF
--- a/source/css/_layout/footer.styl
+++ b/source/css/_layout/footer.styl
@@ -10,7 +10,7 @@
       position: absolute
       width: 100%
       height: 100%
-      background-color: alpha($dark-black, .5)
+      background-color: alpha($dark-black,0)
       content: ''
 
 #footer-wrap

--- a/source/css/_layout/head.styl
+++ b/source/css/_layout/head.styl
@@ -11,7 +11,7 @@
     position: absolute
     width: 100%
     height: 100%
-    background-color: alpha($dark-black, .3)
+    background-color: alpha($dark-black,0)
     content: ''
 
   // index


### PR DESCRIPTION
感觉一流图的效果更好唉
很多bloger都会添加CSS去除这个效果
或者接下来可以在config.yml中增加是否去除黑玻璃的选项
![AfterChange1](https://user-images.githubusercontent.com/59521292/169651943-71110b34-51ff-4229-b8f5-d85db21d3a54.gif)
![AfterChange2](https://user-images.githubusercontent.com/59521292/169651949-911bc1af-3f69-41d8-a577-1d4f2442fda4.png)
![BeforeChange1](https://user-images.githubusercontent.com/59521292/169651951-1b18c3ae-605c-42b9-b74b-697c335098c0.gif)
![BeforeChange2](https://user-images.githubusercontent.com/59521292/169651955-6a2bc0c0-f9b6-4d75-b222-7f82c0b24148.png)
