### PR TITLE
fix：侧边栏归档卡片自定义排序异常

### DIFF
--- a/source/css/_layout/aside.styl
+++ b/source/css/_layout/aside.styl
@@ -403,7 +403,7 @@
 
   if hexo-config('aside.card_archives.sort_order')
     .card-archives
-      order: hexo-config('aside.card-archives.sort_order')
+      order: hexo-config('aside.card_archives.sort_order')
 
   if hexo-config('aside.card_webinfo.sort_order')
     .card-webinfo


### PR DESCRIPTION
过了这么久也没人发现，我在想最初帮忙测试的时候怎么没发现，到今天测试时才发现