### PR TITLE
Update third-party.styl

### DIFF
--- a/source/css/_layout/third-party.styl
+++ b/source/css/_layout/third-party.styl
@@ -86,7 +86,6 @@ mjx-container[display],
 .has-jax
   overflow-x: auto
   overflow-y: hidden
-  line-height: normal !important
 
 .aplayer
   color: $font-black


### PR DESCRIPTION
这行代码似乎本身是为了修复`mathjax`显示不全的bug，但在本人使用的浏览器(chrome)上反而引入了显示的问题，具体表现是**破坏了带有行内公式段落的行距**，而去除后恢复正常。由于不熟悉开发逻辑，这里提交一个拉取请求供参考。

This line was likely to to solve the bug that `mathjax` formula were not displayed appropriately, while **it has in the contrary led to abnormal line spread** on my browser (chrome). Through testing, I found that simply removing this line is helpful. Since I am not a developer and not sure whether this is universal, I decide to create a pull request here for your information.