### PR TITLE
fix: 固定导航栏后文章标题滚动高度出现问题

### DIFF
--- a/layout/includes/head/config.pug
+++ b/layout/includes/head/config.pug
@@ -124,5 +124,6 @@ script.
     percent: {
       toc: !{theme.toc.scroll_percent},
       rightside: !{theme.rightside_scroll_percent},
-    }
+    },
+    isNavFixed: !{theme.nav.fixed ? true : false},
   }

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -122,11 +122,11 @@ const btf = {
 
   scrollToDest: (pos, time = 500) => {
     const currentPos = window.pageYOffset
-    if (currentPos > pos) pos = pos - 70
+    if (currentPos > pos && !GLOBAL_CONFIG.isNavFixed) pos = pos - 70
 
     if ('scrollBehavior' in document.documentElement.style) {
       window.scrollTo({
-        top: pos,
+        top: GLOBAL_CONFIG.isNavFixed ? pos - 70 : pos,
         behavior: 'smooth'
       })
       return


### PR DESCRIPTION
修复开启导航栏固定后，点击目录会导致文章标题被导航栏遮盖的问题