### PR TITLE
FIX mathjax在ajax啓用時，可能的重置錯誤

### DIFF
--- a/layout/includes/third-party/math/mathjax.pug
+++ b/layout/includes/third-party/math/mathjax.pug
@@ -43,5 +43,5 @@ script.
   } else {
     MathJax.startup.document.state(0)
     MathJax.texReset()
-    MathJax.typeset()
+    MathJax.typesetPromise()
   }


### PR DESCRIPTION
當Ajax啓用時，如果從HomePage進入未包含任何Mathjax源代碼的頁面，然後再通過Ajax加載另一個包含Mathjax源代碼的頁面，此時使用MathJax.typeset()將引發"Mathjax Retry"錯誤，導致新頁面的Mathjax源代碼無法被正常渲染。
通過使用Mathjax.typesetPromise()可以避免這種可能的情況。
詳細見：https://docs.mathjax.org/en/latest/advanced/typeset.html