### PR TITLE
local search增添标签搜索功能

### DIFF
--- a/source/js/search/local-search.js
+++ b/source/js/search/local-search.js
@@ -220,7 +220,7 @@ window.addEventListener('load', () => {
                     splitTags = splitTags.concat(splitT[i])
                   }else{
                     if(space===0){
-                      splitTags = splitTags + '</span></i><i class="fas fa-tag"><span style="font-family:times">'
+                      splitTags = splitTags + '</span></i>&nbsp &nbsp<i class="fas fa-tag"><span style="font-family:times">'
                       space = 1
                     }
                   }         

--- a/source/js/search/local-search.js
+++ b/source/js/search/local-search.js
@@ -118,6 +118,7 @@ window.addEventListener('load', () => {
                 for(let i=0; i<dataTags.length;i++){
                   dataTags0 = dataTags0.concat(dataTags[i].replace(/<[^>]+>/g, ''))
                 }
+                dataTags0 = dataTags0.trim().toLowerCase()
                 indexTag = dataTags0.indexOf(keyword)
                 if ( indexTag < 0 ){
                   isMatch = false

--- a/source/js/search/local-search.js
+++ b/source/js/search/local-search.js
@@ -192,7 +192,10 @@ window.addEventListener('load', () => {
                 //- 自定义开始：生成的搜索结果框里，加入显示tags
                 let splitT = '' 
                 //- 第一步：下面是去掉dataTags里非汉字和字母（数字）的部分，然后用两个汉字分号'；；'把各个tags分隔开（保存在spliT变量里）
-                let space=0
+                // for(let i=0;i<dataTags.length;i++){
+                //   splitT = splitT.concat(dataTags[i])+'；；'
+                // }
+                let space = 1
                 for (let i=0;i<dataTags.length;i++){
                   if (/\S/.test(dataTags[i])){ 
                     // \S 匹配Unicode非空白
@@ -205,12 +208,7 @@ window.addEventListener('load', () => {
                     } 
                   }          
                 }
-                //去掉splitT开头和结尾的；；
-                for(let i=0;i<splitT.length;i++){
-                  if(splitT[0]=='；' && splitT.length>1){
-                    splitT = splitT.substring(1)
-                  }
-                }
+                //去掉splitT末尾的双分号；；
                 for(let i=0;i<splitT.length;i++){
                   let l = splitT.length
                   if(splitT[l-1]=='；' && l>1){
@@ -229,7 +227,7 @@ window.addEventListener('load', () => {
 
                 //- 第三步：由于第一步生产的为纯文本且包括双分号，此步骤去掉分号且加上fas fa-tag、控制字体（保存在splitTags里）
                 let splitTags = '<br/><i class="fas fa-tag"><span style="font-family:times">'
-                space = 0
+                space = 1
                 for(let i=0;i<splitT.length;i++){
                   if(splitT[i] !== '；'){
                     space = 0

--- a/source/js/search/local-search.js
+++ b/source/js/search/local-search.js
@@ -182,7 +182,7 @@ window.addEventListener('load', () => {
                 dataTitle = dataTitle.replace(regS, '<span class="search-keyword">' + keyword + '</span>')
               })
 
-              str += '<div class="local-search__hit-item"><a href="' + dataUrl + '" class="search-result-title"' + dataTitle + '</a>'
+              str += '<div class="local-search__hit-item"><a href="' + dataUrl + '"><span class="search-result-title">' + dataTitle + '</span>'
               count += 1
               
               if (dataContent !== '') {

--- a/source/js/search/local-search.js
+++ b/source/js/search/local-search.js
@@ -97,15 +97,15 @@ window.addEventListener('load', () => {
       dataObj.then(data => {
         data.forEach(data => {
           let isMatch = true
-          let dataTitle = data.title ? data.title.trim().toLowerCase() : ''  //获取标题
-          const dataContent = data.content ? data.content.trim().replace(/<[^>]+>/g, '').toLowerCase() : '' //获取正文,其中【.replace(/<[^>]+>/g, '')】去掉了网页标签
-          const dataUrl = data.url.startsWith('/') ? data.url : GLOBAL_CONFIG.root + data.url //获取链接
-          const dataTags = data.tags ? data.tags : ''  //获取标签
+          let dataTitle = data.title ? data.title.trim().toLowerCase() : ''  //- 获取标题
+          const dataContent = data.content ? data.content.trim().replace(/<[^>]+>/g, '').toLowerCase() : '' //- 获取正文,其中【.replace(/<[^>]+>/g, '')】去掉了网页标签
+          const dataUrl = data.url.startsWith('/') ? data.url : GLOBAL_CONFIG.root + data.url //- 获取链接
+          const dataTags = data.tags ? data.tags : ''  //- 获取标签
           let indexTitle = -1
           let indexContent = -1
           let firstOccur = -1
           let indexTag = -1	//- +++添加标签定位变量
-          let l_keywords = keywords.toString().split('').length //- +++获取搜索关键词的长度
+          let l_keywords = keywords.toString().split('').length //- 获取搜索关键词的长度
           // only match articles with not empty titles and contents
           if (dataTitle !== '' || dataContent !== '') {
             keywords.forEach((keyword, i) => {
@@ -114,7 +114,10 @@ window.addEventListener('load', () => {
                 //如果关键词第一个字符是#且长度大于1，那么进行tag搜索
                 keyword = keyword.substring(1) // 将关键词第一个#去掉后再匹配
                 //- 定义dataTags0的意义：去掉tags里面的网页标签代码，否则会把网页标签里面的代码（非正文内容）也匹配
-                let dataTags0 = dataTags.replace(/<[^>]+>/g, '')
+                let dataTags0 = ''
+                for(let i=0; i<dataTags.length;i++){
+                  dataTags0 = dataTags0.concat(dataTags[i].replace(/<[^>]+>/g, ''))
+                }
                 indexTag = dataTags0.indexOf(keyword)
                 if ( indexTag < 0 ){
                   isMatch = false
@@ -240,7 +243,7 @@ window.addEventListener('load', () => {
                 }
                 splitTags = splitTags + '</span></i>'
                 
-                post = dataTags!== '' ? post  + splitTags : post
+                post = dataTags === [] ?  post : post  + splitTags
                 //- 自定义结束
               
                 str += '<p class="search-result">' + pre + matchContent + post + '</p>'

--- a/source/js/search/local-search.js
+++ b/source/js/search/local-search.js
@@ -60,7 +60,8 @@ window.addEventListener('load', () => {
         return {
           title: item.querySelector('title').textContent,
           content: item.querySelector('content') && item.querySelector('content').textContent,
-          url: item.querySelector('url').textContent
+          url: item.querySelector('url').textContent,
+          tags: item.querySelector('tags') && item.querySelector('tags').textContent
         }
       })
     }
@@ -96,25 +97,43 @@ window.addEventListener('load', () => {
       dataObj.then(data => {
         data.forEach(data => {
           let isMatch = true
-          let dataTitle = data.title ? data.title.trim().toLowerCase() : ''
-          const dataContent = data.content ? data.content.trim().replace(/<[^>]+>/g, '').toLowerCase() : ''
-          const dataUrl = data.url.startsWith('/') ? data.url : GLOBAL_CONFIG.root + data.url
+          let dataTitle = data.title ? data.title.trim().toLowerCase() : ''  //获取标题
+          const dataContent = data.content ? data.content.trim().replace(/<[^>]+>/g, '').toLowerCase() : '' //获取正文,其中【.replace(/<[^>]+>/g, '')】去掉了网页标签
+          const dataUrl = data.url.startsWith('/') ? data.url : GLOBAL_CONFIG.root + data.url //获取链接
+          const dataTags = data.tags ? data.tags.trim().toLowerCase() : ''  //获取标签
           let indexTitle = -1
           let indexContent = -1
           let firstOccur = -1
+          let indexTag = -1	//- +++添加标签定位变量
+          let l_keywords = keywords.toString().split('').length //- +++获取搜索关键词的长度
           // only match articles with not empty titles and contents
           if (dataTitle !== '' || dataContent !== '') {
             keywords.forEach((keyword, i) => {
-              indexTitle = dataTitle.indexOf(keyword)
-              indexContent = dataContent.indexOf(keyword)
-              if (indexTitle < 0 && indexContent < 0) {
-                isMatch = false
-              } else {
-                if (indexContent < 0) {
-                  indexContent = 0
+              // keywords是一个Object，keywords[0]包含了关键词的所有内容，因此要用keywords[0][0]
+              if (keywords[0][0] === '#' && l_keywords > 1 && keywords[0][1] !== '#'){ //- 最后一个判断条件修复了正文中'##'无法搜索的问题
+                //如果关键词第一个字符是#且长度大于1，那么进行tag搜索
+                keyword = keyword.substring(1) // 将关键词第一个#去掉后再匹配
+                //- 定义dataTags0的意义：去掉tags里面的网页标签代码，否则会把网页标签里面的代码（非正文内容）也匹配
+                let dataTags0 = dataTags.replace(/<[^>]+>/g, '')
+                indexTag = dataTags0.indexOf(keyword)
+                if ( indexTag < 0 ){
+                  isMatch = false
+                }else{
+                  firstOccur = 0
                 }
-                if (i === 0) {
-                  firstOccur = indexContent
+              }else{
+                //如果第一个字母不是#,那么不匹配标签
+                indexTitle = dataTitle.indexOf(keyword)
+                indexContent = dataContent.indexOf(keyword)
+                if (indexTitle < 0 && indexContent < 0) {
+                  isMatch = false
+                } else {
+                  if (indexContent < 0) {
+                    indexContent = 0
+                  }
+                  if (i === 0) {
+                    firstOccur = indexContent
+                  }
                 }
               }
             })
@@ -163,10 +182,54 @@ window.addEventListener('load', () => {
                 dataTitle = dataTitle.replace(regS, '<span class="search-keyword">' + keyword + '</span>')
               })
 
-              str += '<div class="local-search__hit-item"><a href="' + dataUrl + '" class="search-result-title">' + dataTitle + '</a>'
+              str += '<div class="local-search__hit-item"><a href="' + dataUrl + '" class="search-result-title" target="_blank">' + dataTitle + '</a>'
               count += 1
 
               if (dataContent !== '') {
+                //- 自定义开始：生成的搜索结果框里，加入显示tags
+                let splitT = '' 
+                //- 第一步：下面是去掉dataTags里非汉字和字母（数字）的部分，然后用两个汉字分号'；；'把各个tags分隔开（保存在spliT变量里）
+                let space=0
+                for (let i=0;i<dataTags.length;i++){
+                  if (/^[\u4e00-\u9fa5a-zA-Z]*$/.test(dataTags[i])){
+                    space = 0
+                    splitT = splitT.concat(dataTags[i])
+                  }else{
+                    if(space===0){
+                      splitT = splitT + '；；' 
+                      space = 1
+                    } 
+                  }          
+                }
+                
+                //- 第二步： highlight all keywords
+                keywords.forEach(keyword => {
+                  if(keyword[0] === '#' & keyword.length>1){
+                    keyword = keyword.substring(1) // 如果第一个字符为#且长度大于1，将关键词第一个#去掉后再匹配
+                  }
+                  const regS = new RegExp(keyword, 'gi')
+                  splitT = splitT.replace(regS, '<span class="search-keyword">' + keyword + '</span>')
+                }) 
+
+                //- 第三步：由于第一步生产的为纯文本且包括双分号，此步骤去掉分号且加上fas fa-tag、控制字体（保存在splitTags里）
+                let splitTags = '<br/><i class="fas fa-tag"><span style="font-family:times">'
+                space = 0
+                for(let i=0;i<splitT.length;i++){
+                  if(splitT[i] !== '；'){
+                    space = 0
+                    splitTags = splitTags.concat(splitT[i])
+                  }else{
+                    if(space===0){
+                      splitTags = splitTags + '</span></i><i class="fas fa-tag"><span style="font-family:times">'
+                      space = 1
+                    }
+                  }         
+                }
+                splitTags = splitTags + '</span></i>'
+                
+                post = dataTags!== '' ? post  + splitTags : post
+                //- 自定义结束
+              
                 str += '<p class="search-result">' + pre + matchContent + post + '</p>'
               }
             }

--- a/source/js/search/local-search.js
+++ b/source/js/search/local-search.js
@@ -100,7 +100,7 @@ window.addEventListener('load', () => {
           let dataTitle = data.title ? data.title.trim().toLowerCase() : ''  //获取标题
           const dataContent = data.content ? data.content.trim().replace(/<[^>]+>/g, '').toLowerCase() : '' //获取正文,其中【.replace(/<[^>]+>/g, '')】去掉了网页标签
           const dataUrl = data.url.startsWith('/') ? data.url : GLOBAL_CONFIG.root + data.url //获取链接
-          const dataTags = data.tags ? data.tags.trim().toLowerCase() : ''  //获取标签
+          const dataTags = data.tags ? data.tags : ''  //获取标签
           let indexTitle = -1
           let indexContent = -1
           let firstOccur = -1
@@ -182,16 +182,17 @@ window.addEventListener('load', () => {
                 dataTitle = dataTitle.replace(regS, '<span class="search-keyword">' + keyword + '</span>')
               })
 
-              str += '<div class="local-search__hit-item"><a href="' + dataUrl + '" class="search-result-title" target="_blank">' + dataTitle + '</a>'
+              str += '<div class="local-search__hit-item"><a href="' + dataUrl + '" class="search-result-title"' + dataTitle + '</a>'
               count += 1
-
+              
               if (dataContent !== '') {
                 //- 自定义开始：生成的搜索结果框里，加入显示tags
                 let splitT = '' 
                 //- 第一步：下面是去掉dataTags里非汉字和字母（数字）的部分，然后用两个汉字分号'；；'把各个tags分隔开（保存在spliT变量里）
                 let space=0
                 for (let i=0;i<dataTags.length;i++){
-                  if (/^[\u4e00-\u9fa5a-zA-Z]*$/.test(dataTags[i])){
+                  if (/\S/.test(dataTags[i])){ 
+                    // \S 匹配Unicode非空白
                     space = 0
                     splitT = splitT.concat(dataTags[i])
                   }else{
@@ -200,6 +201,18 @@ window.addEventListener('load', () => {
                       space = 1
                     } 
                   }          
+                }
+                //去掉splitT开头和结尾的；；
+                for(let i=0;i<splitT.length;i++){
+                  if(splitT[0]=='；' && splitT.length>1){
+                    splitT = splitT.substring(1)
+                  }
+                }
+                for(let i=0;i<splitT.length;i++){
+                  let l = splitT.length
+                  if(splitT[l-1]=='；' && l>1){
+                    splitT = splitT.substring(0,l-2)
+                  }
                 }
                 
                 //- 第二步： highlight all keywords

--- a/source/js/search/local-search.js
+++ b/source/js/search/local-search.js
@@ -182,7 +182,7 @@ window.addEventListener('load', () => {
                 dataTitle = dataTitle.replace(regS, '<span class="search-keyword">' + keyword + '</span>')
               })
 
-              str += '<div class="local-search__hit-item"><a href="' + dataUrl + '"><span class="search-result-title">' + dataTitle + '</span>'
+              str += '<div class="local-search__hit-item"><a href="' + dataUrl + '" class="search-result-title" target="_blank">' + dataTitle + '</a>'
               count += 1
               
               if (dataContent !== '') {

--- a/source/js/search/local-search.js
+++ b/source/js/search/local-search.js
@@ -192,9 +192,6 @@ window.addEventListener('load', () => {
                 //- 自定义开始：生成的搜索结果框里，加入显示tags
                 let splitT = '' 
                 //- 第一步：下面是去掉dataTags里非汉字和字母（数字）的部分，然后用两个汉字分号'；；'把各个tags分隔开（保存在spliT变量里）
-                // for(let i=0;i<dataTags.length;i++){
-                //   splitT = splitT.concat(dataTags[i])+'；；'
-                // }
                 let space = 1
                 for (let i=0;i<dataTags.length;i++){
                   if (/\S/.test(dataTags[i])){ 


### PR DESCRIPTION
实现了两个功能：
第一，在搜索结果的界面，除了显示文章的一部分正文外，还显示了标签；
第二，可以按照标签进行搜索。（方法为在搜索框输入’#‘+关键字）

效果图如下：
<div align='left'>
  <img src='https://user-images.githubusercontent.com/69998456/217470396-8e9f3a07-8519-4540-a2e7-d234e8b220cf.png' width=400px>
</div>

当然很遗憾，搜索框输入英文问号的bug我没有能力修复，还要麻烦您