### PR TITLE
bugfix: 标题与post背景图融合[已解决]

### DIFF
--- a/layout/includes/head.pug
+++ b/layout/includes/head.pug
@@ -55,7 +55,7 @@ if theme.fancybox
 !=partial('includes/head/analytics', {}, {cache: true})
 
 //- font
-if theme.blog_title_font &&　theme.blog_title_font.font_link
+if theme.blog_title_font && theme.blog_title_font.font_link
   link(rel='stylesheet' href=url_for(theme.blog_title_font.font_link) media="print" onload="this.media='all'")
 
 //- global config

--- a/source/css/_layout/head.styl
+++ b/source/css/_layout/head.styl
@@ -95,6 +95,16 @@
   &.post-bg
     height: 400px
 
+    // darken the background to make the title visible
+    &::before
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0, 0, 0, 0.3);
+
     +maxWidth768()
       height: 360px
 


### PR DESCRIPTION
before :
![image](https://github.com/jerryc127/hexo-theme-butterfly/assets/96735231/fa4112a0-71e6-41fd-bbdd-e58e94a4237a)
after :
![image](https://github.com/jerryc127/hexo-theme-butterfly/assets/96735231/1d35e6eb-6365-4bf0-866c-b7816f6468ba)
