### PR TITLE
feat: 为特定语言配置其代码块默认展开或收起

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,10 @@ highlight_lang: true # show the code language
 highlight_shrink: false # true: shrink the code blocks / false: expand the code blocks | none: expand code blocks and hide the button
 highlight_height_limit: false # unit: px
 code_word_wrap: false
+highlight_always_expand: # always expand the code blocks for specific languages
+  # - cpp
+  # - java
+highlight_always_collapse: # always collapse the code blocks for specific languages
 
 # Social Settings (社交圖標設置)
 # formal:

--- a/layout/includes/head/config_site.pug
+++ b/layout/includes/head/config_site.pug
@@ -17,6 +17,27 @@
     const pageToc = page.toc === true || page.toc === false ? page.toc : tocEnable
     showToc = pageToc && (toc(page.content) !== '' || page.encrypt == true )
   }
+
+  function selectLangAttributes(global, curr) {
+    function convertLangNames(set) {
+      if (set === undefined) return undefined
+      if (Array.isArray(set)) {
+        return set.join(',');
+      } else if (set == '') {
+        return ''
+      } else {
+        return set + ''
+      }
+    }
+    global = convertLangNames(global)
+    curr = convertLangNames(curr)
+    if (curr !== undefined) return curr
+    else if (global !== undefined) return global
+    return ''
+  }
+  let highlightLangAlwaysExpand = selectLangAttributes(theme.highlight_always_expand, page.highlight_always_expand)
+  let highlightLangAlwaysCollapse = selectLangAttributes(theme.highlight_always_collapse, page.highlight_always_collapse)
+
 -
 
 script#config-diff.
@@ -26,5 +47,7 @@ script#config-diff.
     isHome: !{is_home()},
     isHighlightShrink: !{isHighlightShrink},
     isToc: !{showToc},
-    postUpdate: '!{full_date(page.updated)}'
+    postUpdate: '!{full_date(page.updated)}',
+    highlightLangExpand: '!{highlightLangAlwaysExpand}',
+    highlightLangCollapse: '!{highlightLangAlwaysCollapse}'
   }

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -72,15 +72,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const { highlightCopy, highlightLang, highlightHeightLimit, plugin } = highLight
     const isHighlightShrink = GLOBAL_CONFIG_SITE.isHighlightShrink
+    const highlightLangExpand = GLOBAL_CONFIG_SITE.highlightLangExpand.split(',')
+    const highlightLangCollapse = GLOBAL_CONFIG_SITE.highlightLangCollapse.split(',')
     const isShowTool = highlightCopy || highlightLang || isHighlightShrink !== undefined
     const $figureHighlight = plugin === 'highlighjs' ? document.querySelectorAll('figure.highlight') : document.querySelectorAll('pre[class*="language-"]')
 
     if (!((isShowTool || highlightHeightLimit) && $figureHighlight.length)) return
 
     const isPrismjs = plugin === 'prismjs'
-    const highlightShrinkClass = isHighlightShrink === true ? 'closed' : ''
-    const highlightShrinkEle = isHighlightShrink !== undefined ? `<i class="fas fa-angle-down expand ${highlightShrinkClass}"></i>` : ''
-    const highlightCopyEle = highlightCopy ? '<div class="copy-notice"></div><i class="fas fa-paste copy-button"></i>' : ''
 
     const copy = (text, ctx) => {
       if (document.queryCommandSupported && document.queryCommandSupported('copy')) {
@@ -138,8 +137,16 @@ document.addEventListener('DOMContentLoaded', function () {
       this.classList.toggle('expand-done')
     }
 
-    function createEle (lang, item, service) {
+    function createEle (lang, langName, item, service) {
       const fragment = document.createDocumentFragment()
+      var isHighlightShrinkLocal = isHighlightShrink
+      if (isHighlightShrinkLocal !== undefined) {
+        if (highlightLangExpand.includes(langName)) isHighlightShrinkLocal = false
+        else if (highlightLangCollapse.includes(langName)) isHighlightShrinkLocal = true
+      }
+      const highlightShrinkClass = isHighlightShrinkLocal === true ? 'closed' : ''
+      const highlightShrinkEle = isHighlightShrinkLocal !== undefined ? `<i class="fas fa-angle-down expand ${highlightShrinkClass}"></i>` : ''
+      const highlightCopyEle = highlightCopy ? '<div class="copy-notice"></div><i class="fas fa-paste copy-button"></i>' : ''
 
       if (isShowTool) {
         const hlTools = document.createElement('div')
@@ -170,10 +177,10 @@ document.addEventListener('DOMContentLoaded', function () {
           const langName = item.getAttribute('data-language') || 'Code'
           const highlightLangEle = `<div class="code-lang">${langName}</div>`
           btf.wrap(item, 'figure', { class: 'highlight' })
-          createEle(highlightLangEle, item)
+          createEle(highlightLangEle, langName, item)
         } else {
           btf.wrap(item, 'figure', { class: 'highlight' })
-          createEle('', item)
+          createEle('', '', item)
         }
       })
     } else {
@@ -182,9 +189,9 @@ document.addEventListener('DOMContentLoaded', function () {
           let langName = item.getAttribute('class').split(' ')[1]
           if (langName === 'plain' || langName === undefined) langName = 'Code'
           const highlightLangEle = `<div class="code-lang">${langName}</div>`
-          createEle(highlightLangEle, item, 'hl')
+          createEle(highlightLangEle, langName, item, 'hl')
         } else {
-          createEle('', item, 'hl')
+          createEle('', '', item, 'hl')
         }
       })
     }
@@ -264,8 +271,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const addJustifiedGallery = () => {
       ele.forEach(item => {
         item.classList.contains('url')
-          ? fetchUrl(item.textContent).then(res => { runJustifiedGallery(item, res) })
-          : runJustifiedGallery(item, JSON.parse(item.textContent))
+            ? fetchUrl(item.textContent).then(res => { runJustifiedGallery(item, res) })
+            : runJustifiedGallery(item, JSON.parse(item.textContent))
       })
     }
 
@@ -358,8 +365,8 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   /**
-  * toc,anchor
-  */
+   * toc,anchor
+   */
   const scrollFnToDo = function () {
     const isToc = GLOBAL_CONFIG_SITE.isToc
     const isAnchor = GLOBAL_CONFIG.isAnchor
@@ -395,8 +402,8 @@ document.addEventListener('DOMContentLoaded', function () {
         const target = e.target.classList
         if (target.contains('toc-content')) return
         const $target = target.contains('toc-link')
-          ? e.target
-          : e.target.parentElement
+            ? e.target
+            : e.target.parentElement
         btf.scrollToDest(btf.getEleTop(document.getElementById(decodeURI($target.getAttribute('href')).replace('#', ''))), 300)
         if (window.innerWidth < 900) {
           window.mobileToc.close()
@@ -595,8 +602,8 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   /**
- * 複製時加上版權信息
- */
+   * 複製時加上版權信息
+   */
   const addCopyright = () => {
     const copyright = GLOBAL_CONFIG.copyright
     document.body.oncopy = (e) => {


### PR DESCRIPTION
现在主题配置中只能选择所有代码块的展开/收起。
这个PR的更改使得使用者可以配置全局（或单独某个页面）为一个或多个语言的代码块默认展开或收起。
