### PR TITLE
feat: 新增修改单独页面宽度的功能

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -622,6 +622,16 @@ site_verification:
 #   meta_theme_color_light: "ffffff"
 #   meta_theme_color_dark: "#0d0d0d"
 
+# Modify the width of different pages
+# Notice: width value must in double quotes like "1400px" or may cause error!
+
+# pages_width:
+#   enable: true
+#   homepage: "1400px"
+#   categories: "1400px"
+#   tags: "1400px"
+#   archives: "1400px"
+
 # The top_img settings of home page
 # default: top img - full screen, site info - middle (默認top_img全屏，site_info在中間)
 # The position of site info, eg: 300px/300em/300rem/10% (主頁標題距離頂部距離)

--- a/source/css/_global/index.styl
+++ b/source/css/_global/index.styl
@@ -36,6 +36,10 @@
   --default-bg-color: $theme-color
   --zoom-bg: #fff
   --mark-bg: alpha($dark-black, .3)
+  --homepage-width: $homepage-width
+  --categories-width: $categories-width
+  --tags-width: $tags-width
+  --archives-width: $archives-width
 
 body
   position: relative

--- a/source/css/_page/common.styl
+++ b/source/css/_page/common.styl
@@ -11,6 +11,18 @@
   max-width: 1200px
   width: 100%
 
+  .page:has(#recent-posts) &
+    max-width: var(--homepage-width)
+
+  .page:has(.article-sort) &
+    max-width: var(--archives-width)
+
+  .page:has(.category-lists) &
+    max-width: var(--categories-width)
+
+  .page:has(.tag-cloud-list) &
+    max-width: var(--tags-width)
+
   +maxWidth900()
     flex-direction: column
 

--- a/source/css/var.styl
+++ b/source/css/var.styl
@@ -184,3 +184,9 @@ $tab-to-top-hover-color = $theme-color
 $timeline-default-color = $theme-color
 // archor
 $archor-button-icon = hexo-config('anchor.button.icon') ? hexo-config('anchor.button.icon') : '\f0c1'
+// width
+$pagesWidthEnable = hexo-config('pages_width') && hexo-config('pages_width.enable')
+$homepage-width = $pagesWidthEnable && hexo-config('pages_width.homepage') ? convert(hexo-config('pages_width.homepage')) : 1200px
+$categories-width = $pagesWidthEnable && hexo-config('pages_width.categories') ? convert(hexo-config('pages_width.categories')) : 1200px
+$tags-width = $pagesWidthEnable && hexo-config('pages_width.tags') ? convert(hexo-config('pages_width.tags')) : 1200px
+$archives-width = $pagesWidthEnable && hexo-config('pages_width.archives') ? convert(hexo-config('pages_width.archives')) : 1200px


### PR DESCRIPTION
和butterfly爱好者交流时，发现他们都有过**修改某些单独page页面宽度**的念头
在categories、tags和archives这些页面去掉侧边栏，并减小page宽度也是一种较为美观的做法
奈何很多人不太懂css或者stylus语法，只能做到同时修改全站宽度
于是在_config.yml中新增pages_width项，达到可选择的配置主页、categories、tags和archives这些页面宽度的目的
about和link这两个页面我暂时还没找到修改的方法 QAQ
**具体效果**可以参考我的博客中的分类页：https://rickliu.com/categories/
