### PR TITLE
fix: string inject html error

### DIFF
--- a/scripts/helpers/page.js
+++ b/scripts/helpers/page.js
@@ -53,8 +53,16 @@ hexo.extend.helper.register('md5', function (path) {
 })
 
 hexo.extend.helper.register('injectHtml', function (data) {
-  if (!data) return ''
-  return data.join('')
+  switch (true) {
+    case typeof data === 'string':
+      return data
+
+    case  Array.isArray(data):
+      return data.join('')
+
+    default:
+      return ''
+  }
 })
 
 hexo.extend.helper.register('findArchivesTitle', function (page, menu, date) {


### PR DESCRIPTION
修复字符串类型 inject html 的报错

```
data.join is not a function
```

<img width="836" alt="Snipaste_2023-10-13_23-09-23" src="https://github.com/jerryc127/hexo-theme-butterfly/assets/10150208/b5d8d18d-804b-44e4-b61f-bc587251e90b">