### PR TITLE
Add "fastly.jsdelivr.net", a jsdelivr domain name that is not polluted by DNS, to optimise access in China Areas to jsdelivr.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -924,7 +924,7 @@ CDN:
   internal_provider: local
 
   # The CDN provider of third party scripts (第三方 js 的 cdn 配置)
-  # option: local/jsdelivr/unpkg/cdnjs/custom
+  # option: local/jsdelivr/fastly_jsdelivr/unpkg/cdnjs/custom
   # when set it to local, you need to install hexo-butterfly-extjs
   third_party_provider: jsdelivr
 

--- a/scripts/events/cdn.js
+++ b/scripts/events/cdn.js
@@ -68,6 +68,7 @@ hexo.extend.filter.register('before_generate', () => {
       const cdnSource = {
         local: cond === 'internal' ? `${cdnjs_file + verType}` : `/pluginsSrc/${name}/${file + verType}`,
         jsdelivr: `https://cdn.jsdelivr.net/npm/${name}${verType}/${min_file}`,
+        fastly_jsdelivr: `https://fastly.jsdelivr.net/npm/${name}${verType}/${min_file}`,
         unpkg: `https://unpkg.com/${name}${verType}/${file}`,
         cdnjs: `https://cdnjs.cloudflare.com/ajax/libs/${cdnjs_name}/${version}/${min_cdnjs_file}`,
         custom: (CDN.custom_format || '').replace(/\$\{(.+?)\}/g, (match, $1) => value[$1])


### PR DESCRIPTION
Add "fastly.jsdelivr.net", a jsdelivr domain name that is not polluted by DNS, to optimise access in China Areas to jsdelivr.