### PR TITLE
bugfix：修复编辑时 series 标签内文章重复的问题

### DIFF
--- a/scripts/tag/series.js
+++ b/scripts/tag/series.js
@@ -15,6 +15,12 @@ const groups = {}
 hexo.extend.filter.register('before_post_render', data => {
   if (!hexo.theme.config.series.enable) return data
   const { layout, series } = data
+  // clear the groups map to avoid duplicated post list
+  for (let key in groups) {
+    if (groups.hasOwnProperty(key)) {
+      delete groups[key]
+    }
+  }
   if (layout === 'post' && series) {
     groups[series] = groups[series] || []
     groups[series].push({


### PR DESCRIPTION
使用 `hexo s` 在编辑时预览文章，如果文章中存在 `series` 标签，则每次保存时标签内的文章都会多重复一次，如图所示：

![bug](https://i.mji.rip/2024/05/11/973ffa949929c23cfa3bae7a514abba0.png)

这是因为每次重新渲染时，所有的文章都会被重新添加到 `series.js` 维护的 `groups` 对象中，因此在每次渲染前清空这一对象即可解决问题