### PR TITLE
bugfix: 修复由于data-prefix设置错误导致busuanzi无法显示的bug

### DIFF
--- a/layout/includes/additional-js.pug
+++ b/layout/includes/additional-js.pug
@@ -60,6 +60,6 @@ div
     != partial("includes/third-party/pjax", {}, { cache: true })
 
   if theme.busuanzi.site_uv || theme.busuanzi.site_pv || theme.busuanzi.page_pv
-    script(async data-pjax src= theme.asset.busuanzi || '//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js')
+    script(async data-pjax src= theme.asset.busuanzi || '//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js' data-prefix="busuanzi_value")
 
   !=partial('includes/third-party/search/index', {}, {cache: true})


### PR DESCRIPTION
由于 [`card_webinfo.pug`第23行](https://github.com/RayKr/hexo-theme-butterfly/blob/fa2c196b30f2e0fa2a112884ca0e136da7489016/layout/includes/widget/card_webinfo.pug#L23C23-L23C45) 中使用的是 `busuanzi_value_site_uv`来获取值的，busuanzi api接口返回数据是 `site_uv`，因此前缀应该是 `busuanzi_value`。而busuanzi默认前缀是 `busuanzi`，因不匹配导致即使配置了CDN后也无法正常显示值。