### PR TITLE
修复背景渐变色无法生效

### DIFF
--- a/scripts/helpers/page.js
+++ b/scripts/helpers/page.js
@@ -82,7 +82,7 @@ hexo.extend.helper.register('getBgPath', path => {
 
   const absoluteUrlPattern = /^(?:[a-z][a-z\d+.-]*:)?\/\//i
   const relativeUrlPattern = /^(\.\/|\.\.\/|\/|[^/]+\/).*$/
-  const colorPattern = /^(#|rgb|rgba|hsl|hsla|linear-gradient|radial-gradient)/i
+  const colorPattern = /^(#|rgb|rgba|hsl|hsla)/i
 
   if (colorPattern.test(path)) {
     return `background-color: ${path};`


### PR DESCRIPTION
修复背景渐变色无法生效
`background-color: linear-gradient(20deg, #0062be, #925696, #cc426e, #fb0347);`
`linear-gradient`应该与`background-image`属性一起使用
`background: linear-gradient(20deg, #0062be, #925696, #cc426e, #fb0347);`