### PR TITLE
feat: 添加结构化数据支持

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1023,6 +1023,13 @@ Open_Graph_meta:
     # fb_admins:
     # fb_app_id:
 
+# Structured Data
+# https://developers.google.com/search/docs/guides/intro-structured-data
+structured_data:
+  enable: true
+  # Choose: json-ld / microdata
+  format: 'json-ld'
+
 # Add the vendor prefixes to ensure compatibility
 css_prefix: true
 

--- a/_config.yml
+++ b/_config.yml
@@ -1025,8 +1025,7 @@ Open_Graph_meta:
 
 # Structured Data
 # https://developers.google.com/search/docs/guides/intro-structured-data
-structured_data:
-  enable: true
+structured_data: true
 
 # Add the vendor prefixes to ensure compatibility
 css_prefix: true

--- a/_config.yml
+++ b/_config.yml
@@ -1027,8 +1027,6 @@ Open_Graph_meta:
 # https://developers.google.com/search/docs/guides/intro-structured-data
 structured_data:
   enable: true
-  # Choose: json-ld / microdata
-  format: 'json-ld'
 
 # Add the vendor prefixes to ensure compatibility
 css_prefix: true

--- a/layout/includes/head.pug
+++ b/layout/includes/head.pug
@@ -25,6 +25,9 @@ meta(name="theme-color" content=themeColor)
 //- Open_Graph
 include ./head/Open_Graph.pug
 
+//- Structured Data
+include ./head/structured_data.pug
+
 !=favicon_tag(theme.favicon || config.favicon)
 link(rel="canonical" href=urlNoIndex(null,config.pretty_urls.trailing_index,config.pretty_urls.trailing_html))
 

--- a/layout/includes/head/structured_data.pug
+++ b/layout/includes/head/structured_data.pug
@@ -1,4 +1,4 @@
-if theme.structured_data.enable && page.layout === 'post'
+if theme.structured_data && page.layout === 'post'
   -
     // use json-ld to add structured data
 

--- a/layout/includes/head/structured_data.pug
+++ b/layout/includes/head/structured_data.pug
@@ -1,6 +1,6 @@
 if theme.structured_data.enable && page.layout === 'post'
   -
-    const format = theme.structured_data.format || 'json-ld'
+    // use json-ld to add structured data
 
     const title = page.title
     const url = page.permalink
@@ -12,47 +12,23 @@ if theme.structured_data.enable && page.layout === 'post'
     const authorHrefVal = page.copyright_author_href || theme.post_copyright.author_href || site.url;
     const authorHref = full_url_for(authorHrefVal);
 
-    if (format === 'json-ld') {
-      const jsonLd = {
-        "@context": "https://schema.org",
-        "@type": "BlogPosting",
-        "headline": title,
-        "url": url,
-        "image": image,
-        "datePublished": datePublished,
-        "dateModified": dateModified,
-        "author": [{
-          "@type": "Person",
-          "name": author,
-          "url": authorHref
-        }]
-      };
+    const jsonLd = {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      "headline": title,
+      "url": url,
+      "image": image,
+      "datePublished": datePublished,
+      "dateModified": dateModified,
+      "author": [{
+        "@type": "Person",
+        "name": author,
+        "url": authorHref
+      }]
+    };
 
-      jsonLdScript = JSON.stringify(jsonLd, null, 2);
-    } else if (format === 'microdata') {
-      microdata = {
-        headline: title,
-        url: url,
-        image: image,
-        datePublished: datePublished,
-        dateModified: dateModified,
-        authorName: author,
-        authorUrl: authorHref
-      };
-    }
+    jsonLdScript = JSON.stringify(jsonLd, null, 2);
   -
 
-  if (format === 'json-ld')
-    script(type="application/ld+json").
-      !{jsonLdScript}
-  else if (format === 'microdata')
-    div(itemscope itemtype="https://schema.org/BlogPosting")
-      meta(itemprop="headline" content=microdata.headline)
-      link(itemprop="url" href=microdata.url)
-      if microdata.image
-        img(itemprop="image" src=microdata.image alt=microdata.headline)
-      meta(itemprop="datePublished" content=microdata.datePublished)
-      meta(itemprop="dateModified" content=microdata.dateModified)
-      div(itemprop="author" itemscope itemtype="https://schema.org/Person")
-        meta(itemprop="name" content=microdata.authorName)
-        link(itemprop="url" href=microdata.authorUrl)
+  script(type="application/ld+json").
+    !{jsonLdScript}

--- a/layout/includes/head/structured_data.pug
+++ b/layout/includes/head/structured_data.pug
@@ -1,0 +1,58 @@
+if theme.structured_data.enable && page.layout === 'post'
+  -
+    const format = theme.structured_data.format || 'json-ld'
+
+    const title = page.title
+    const url = page.permalink
+    const imageVal = page.cover_type === 'img' ? page.cover : theme.avatar.img
+    const image = imageVal ? full_url_for(imageVal) : ''
+    const datePublished = page.date.toISOString()
+    const dateModified = (page.updated || page.date).toISOString()
+    const author = page.copyright_author || config.author
+    const authorHrefVal = page.copyright_author_href || theme.post_copyright.author_href || site.url;
+    const authorHref = full_url_for(authorHrefVal);
+
+    if (format === 'json-ld') {
+      const jsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": title,
+        "url": url,
+        "image": image,
+        "datePublished": datePublished,
+        "dateModified": dateModified,
+        "author": [{
+          "@type": "Person",
+          "name": author,
+          "url": authorHref
+        }]
+      };
+
+      jsonLdScript = JSON.stringify(jsonLd, null, 2);
+    } else if (format === 'microdata') {
+      microdata = {
+        headline: title,
+        url: url,
+        image: image,
+        datePublished: datePublished,
+        dateModified: dateModified,
+        authorName: author,
+        authorUrl: authorHref
+      };
+    }
+  -
+
+  if (format === 'json-ld')
+    script(type="application/ld+json").
+      !{jsonLdScript}
+  else if (format === 'microdata')
+    div(itemscope itemtype="https://schema.org/BlogPosting")
+      meta(itemprop="headline" content=microdata.headline)
+      link(itemprop="url" href=microdata.url)
+      if microdata.image
+        img(itemprop="image" src=microdata.image alt=microdata.headline)
+      meta(itemprop="datePublished" content=microdata.datePublished)
+      meta(itemprop="dateModified" content=microdata.dateModified)
+      div(itemprop="author" itemscope itemtype="https://schema.org/Person")
+        meta(itemprop="name" content=microdata.authorName)
+        link(itemprop="url" href=microdata.authorUrl)

--- a/scripts/events/merge_config.js
+++ b/scripts/events/merge_config.js
@@ -567,9 +567,7 @@ hexo.extend.filter.register('before_generate', () => {
       enable: true,
       option: null
     },
-    structured_data: {
-      enable: true
-    },
+    structured_data: true,
     css_prefix: true,
     inject: {
       head: null,

--- a/scripts/events/merge_config.js
+++ b/scripts/events/merge_config.js
@@ -567,6 +567,10 @@ hexo.extend.filter.register('before_generate', () => {
       enable: true,
       option: null
     },
+    structured_data: {
+      enable: true,
+      format: 'json-ld',
+    },
     css_prefix: true,
     inject: {
       head: null,

--- a/scripts/events/merge_config.js
+++ b/scripts/events/merge_config.js
@@ -568,8 +568,7 @@ hexo.extend.filter.register('before_generate', () => {
       option: null
     },
     structured_data: {
-      enable: true,
-      format: 'json-ld',
+      enable: true
     },
     css_prefix: true,
     inject: {


### PR DESCRIPTION
结构化数据的介绍可见[此链接](https://developers.google.com/search/docs/guides/intro-structured-data)。开启此选项后，会在post的head中添加对应的结构化数据，从而能够优化在Google Search中的显示结果。

一段示例的生成代码如下：
```plaintext
<script type="application/ld+json">{
  "@context": "https://schema.org",
  "@type": "BlogPosting",
  "headline": "关于 Google Play 检查本体更新问题",
  "url": "https://blog.deepchirp.com/2024/09/26/About-Google-Play-Store-Self-Update/",
  "image": "https://blog.deepchirp.com/img/cover/Google-Play-Logo.svg",
  "datePublished": "2024-09-26T07:58:21.000Z",
  "dateModified": "2024-09-28T15:27:28.000Z",
  "author": [
    {
      "@type": "Person",
      "name": "深鸣",
      "url": "https://blog.deepchirp.com/about/"
    }
  ]
}</script>
```

其中`@type`固定为`BlogPosting`，author的`@type`固定为`Person`，其他数据均根据文章内容生成。

在[富媒体搜索结果测试](https://search.google.com/test/rich-results)中能够通过，测试结果见[此链接](https://search.google.com/test/rich-results/result/r%2Farticles?id=QZHvdrdDOoKkKM_anl7BQg)。