### PR TITLE
chore: add `avif` to the list of supported image formats

### DIFF
--- a/scripts/filters/random_cover.js
+++ b/scripts/filters/random_cover.js
@@ -6,7 +6,7 @@
 'use strict'
 
 hexo.extend.filter.register('before_post_render', data => {
-  const imgTestReg = /\.(png|jpe?g|gif|svg|webp)(\?.*)?$/i
+  const imgTestReg = /\.(png|jpe?g|gif|svg|webp|avif)(\?.*)?$/i
   let { cover: coverVal, top_img: topImg } = data
 
   // Add path to top_img and cover if post_asset_folder is enabled


### PR DESCRIPTION
在检测图片的正则表达式中，添加了`avif`格式