### PR TITLE
fix: 代码字体先 fallback 到 monospace 再到中文和 sans-serif

### DIFF
--- a/source/css/var.styl
+++ b/source/css/var.styl
@@ -16,7 +16,7 @@ $theme-toc-color = $themeColorEnable && hexo-config('theme_color.toc_color') ? c
 
 $chinseFont = $language == 'zh-CN' ? 'Microsoft YaHei' : 'Microsoft JhengHei'
 $dafault-font-family = -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Lato, Roboto, 'PingFang SC', $chinseFont, sans-serif
-$dafault-code-font = consolas, Menlo, 'PingFang SC', $chinseFont, sans-serif
+$dafault-code-font = consolas, Menlo, monospace, 'PingFang SC', $chinseFont, sans-serif
 
 $font-family = hexo-config('font.font_family') ? unquote(hexo-config('font.font_family')) : $dafault-font-family
 $code-font-family = hexo-config('font.code_font_family') ? unquote(hexo-config('font.code_font_family')) : $dafault-code-font


### PR DESCRIPTION
现在的情况是在没有 `consolas, Menlo, 'PingFang SC', $chinseFont` 的系统上（比如一般的 Linux 桌面），会 fallback 到 `sans-serif`，导致代码块用的全都是正文字体（非等宽）

另外注意到最终 css 中代码块的 `font-family` 属性包含 `!important`，这是否是必要的？这样对 Stylus 之类的插件不是很友好