### PR TITLE
feat: 删除自定义的滚动条样式

### DIFF
--- a/source/css/_global/index.styl
+++ b/source/css/_global/index.styl
@@ -55,23 +55,6 @@ body
     user-select: none
     -webkit-user-select: none
 
-// scrollbar - firefox
-@-moz-document url-prefix()
-  *
-    scrollbar-width: thin
-    scrollbar-color: var(--scrollbar-color) transparent
-
-// scrollbar - chrome/safari
-*::-webkit-scrollbar
-  width: 5px
-  height: 5px
-
-*::-webkit-scrollbar-thumb
-  background: var(--scrollbar-color)
-
-*::-webkit-scrollbar-track
-  background-color: transparent
-
 input::placeholder
   color: var(--font-color)
 


### PR DESCRIPTION
滚动条太细小了，很难操作，希望恢复到浏览器默认样式。 所以删除这部分