### PR TITLE
fix: update addtoany item reference for correct sharing functionality

### DIFF
--- a/layout/includes/third-party/share/addtoany.pug
+++ b/layout/includes/third-party/share/addtoany.pug
@@ -1,6 +1,6 @@
 .addtoany
   .a2a_kit.a2a_kit_size_32.a2a_default_style
-    - let addtoanyItem = theme.addtoany.item.split(',')
+    - let addtoanyItem = theme.share.addtoany.item.split(',')
     each name in addtoanyItem
       a(class="a2a_button_" + name)
 


### PR DESCRIPTION
In version 5.0, after changing some config formats, the reference location for addtoany was not correspondingly modified, resulting in it not functioning properly.