### PR TITLE
Update pjax.pug

### DIFF
--- a/layout/includes/third-party/pjax.pug
+++ b/layout/includes/third-party/pjax.pug
@@ -59,7 +59,10 @@ script.
 
     document.addEventListener('pjax:error', e => {
       if (e.request.status === 404) {
-        window.location.href = e.request.responseURL
+        const usePjax = !{theme.pjax && theme.pjax.enable}
+        !{theme.error_404 && theme.error_404.enable} 
+          ? (usePjax ? pjax.loadUrl('!{url_for("/404.html")}') : window.location.href = '!{url_for("/404.html")}')
+          : window.location.href = e.request.responseURL
       }
     })
   })()


### PR DESCRIPTION
自定义404.html跳转更平滑，使用 window.location.href = e.request.responseURL 加载，自定义404.html加载速度缓慢，可能会出现loading二次加载