### PR TITLE
feat(score tag): support RenderAbc options

### DIFF
--- a/layout/includes/third-party/abcjs/abcjs.pug
+++ b/layout/includes/third-party/abcjs/abcjs.pug
@@ -1,51 +1,46 @@
 script.
   (function() {
-    var abcjsInit = function() {
-      var abcjsFn = function() {
+    const abcjsInit = function() {
+      const abcjsFn = function() {
         setTimeout(function() {
-          var sheets = document.querySelectorAll(".abc-music-sheet");
-          for (var i = 0; i < sheets.length; i++) {
-            var ele = sheets[i];
-            if (ele.children.length > 0) continue;
-            
-            // 从 data-params 属性中解析参数
-            var params = {};
-            var dp = ele.getAttribute("data-params");
+          const sheets = document.querySelectorAll(".abc-music-sheet")
+          for (let i = 0; i < sheets.length; i++) {
+            const ele = sheets[i]
+            if (ele.children.length > 0) continue
+
+            // Parse parameters from data-params attribute
+            let params = {}
+            const dp = ele.getAttribute("data-params")
             if (dp) {
               try {
-                params = JSON.parse(dp);
+                params = JSON.parse(dp)
               } catch (e) {
-                console.error("解析 data-params 失败：", e);
+                console.error("Failed to parse data-params:", e)
               }
             }
-            
-            // 将解析出的参数与 responsive 参数合并，
-            // 保证 params 中的内容在 responsive 之前
-            var options = {};
-            for (var key in params) {
-              if (params.hasOwnProperty(key)) {
-                options[key] = params[key];
-              }
-            }
-            options.responsive = "resize";
-            
-            // 使用 ABCJS.renderAbc 渲染乐谱
-            ABCJS.renderAbc(ele, ele.innerHTML, options);
+
+            // Merge parsed parameters with the responsive option
+            // Ensures params content appears before responsive
+            const options = { ...params, responsive: "resize" }
+
+            // Render the music score using ABCJS.renderAbc
+            ABCJS.renderAbc(ele, ele.innerHTML, options)
           }
-        }, 100);
-      };
+        }, 100)
+      }
 
       if (typeof ABCJS === "object") {
-        abcjsFn();
+        abcjsFn()
       } else {
-        btf.getScript("!{url_for(theme.asset.abcjs_basic_js)}").then(abcjsFn);
+        btf.getScript("!{url_for(theme.asset.abcjs_basic_js)}").then(abcjsFn)
       }
-    };
+    }
 
     if (window.pjax) {
-      abcjsInit();
+      abcjsInit()
     } else {
-      window.addEventListener("load", abcjsInit);
+      window.addEventListener("load", abcjsInit)
     }
-    btf.addGlobalFn("encrypt", abcjsInit, "abcjs");
-  })();
+
+    btf.addGlobalFn("encrypt", abcjsInit, "abcjs")
+  })()

--- a/layout/includes/third-party/abcjs/abcjs.pug
+++ b/layout/includes/third-party/abcjs/abcjs.pug
@@ -1,17 +1,51 @@
 script.
-  (() => {
-    const abcjsInit = () => {
-      const abcjsFn = () => setTimeout(() => {
-        document.querySelectorAll(".abc-music-sheet").forEach(ele => {
-          if (ele.children.length > 0) return
-          ABCJS.renderAbc(ele, ele.innerHTML, {responsive: 'resize'})
-        })
-      }, 100)
-      
-      typeof ABCJS === 'object' ? abcjsFn()
-        : btf.getScript('!{url_for(theme.asset.abcjs_basic_js)}').then(abcjsFn)
-    }
+  (function() {
+    var abcjsInit = function() {
+      var abcjsFn = function() {
+        setTimeout(function() {
+          var sheets = document.querySelectorAll(".abc-music-sheet");
+          for (var i = 0; i < sheets.length; i++) {
+            var ele = sheets[i];
+            if (ele.children.length > 0) continue;
+            
+            // 从 data-params 属性中解析参数
+            var params = {};
+            var dp = ele.getAttribute("data-params");
+            if (dp) {
+              try {
+                params = JSON.parse(dp);
+              } catch (e) {
+                console.error("解析 data-params 失败：", e);
+              }
+            }
+            
+            // 将解析出的参数与 responsive 参数合并，
+            // 保证 params 中的内容在 responsive 之前
+            var options = {};
+            for (var key in params) {
+              if (params.hasOwnProperty(key)) {
+                options[key] = params[key];
+              }
+            }
+            options.responsive = "resize";
+            
+            // 使用 ABCJS.renderAbc 渲染乐谱
+            ABCJS.renderAbc(ele, ele.innerHTML, options);
+          }
+        }, 100);
+      };
 
-    window.pjax ? abcjsInit() : window.addEventListener('load', abcjsInit)
-    btf.addGlobalFn('encrypt', abcjsInit, 'abcjs')
-  })()
+      if (typeof ABCJS === "object") {
+        abcjsFn();
+      } else {
+        btf.getScript("!{url_for(theme.asset.abcjs_basic_js)}").then(abcjsFn);
+      }
+    };
+
+    if (window.pjax) {
+      abcjsInit();
+    } else {
+      window.addEventListener("load", abcjsInit);
+    }
+    btf.addGlobalFn("encrypt", abcjsInit, "abcjs");
+  })();

--- a/scripts/tag/score.js
+++ b/scripts/tag/score.js
@@ -6,12 +6,12 @@
 'use strict'
 
 const score = (args, content) => {
-  // 转义 HTML 标签和部分特殊字符，包括花括号
+  // Escape HTML tags and some special characters, including curly braces
   const escapeHtmlTags = s => {
     const lookup = {
       '&': '&amp;',
       '"': '&quot;',
-      '\'': '&apos;',
+      "'": '&apos;',
       '<': '&lt;',
       '>': '&gt;',
       '{': '&#123;',
@@ -19,32 +19,32 @@ const score = (args, content) => {
     }
     return s.replace(/[&"'<>{}]/g, c => lookup[c])
   }
-  
+
   const trimmed = content.trim()
-  // 使用六个横线作为分隔符拆分内容
+  // Split content using six dashes as a delimiter
   const parts = trimmed.split('------')
-  
+
   if (parts.length < 2) {
-    // 如果没有分隔符，直接将整个内容作为乐谱内容处理
+    // If no delimiter is found, treat the entire content as the score
     return `<div class="abc-music-sheet">${escapeHtmlTags(trimmed)}</div>`
   }
-  
-  // 第一部分为参数（JSON 字符串），其余部分作为乐谱内容
+
+  // First part is parameters (JSON string), the rest is the score content
   const paramPart = parts[0].trim()
   const scorePart = parts.slice(1).join('------').trim()
-  
+
   let paramsObj = {}
   try {
     paramsObj = JSON.parse(paramPart)
   } catch (e) {
-    console.error('解析 score 标签中的参数 JSON 失败：', e)
+    console.error("Failed to parse JSON in score tag:", e)
   }
-  
-  // 使用双引号包裹 data-params 的属性值，确保 JSON 内部的双引号已被转义
+
+  // Use double quotes for data-params attribute value,
+  // ensuring JSON internal double quotes are escaped
   return `<div class="abc-music-sheet" data-params="${escapeHtmlTags(JSON.stringify(paramsObj))}">
     ${escapeHtmlTags(scorePart)}
   </div>`
 }
 
-hexo.extend.tag.register('score', score, { ends: true })
-
+hexo.extend.tag.register("score", score, { ends: true })

--- a/scripts/tag/score.js
+++ b/scripts/tag/score.js
@@ -6,17 +6,45 @@
 'use strict'
 
 const score = (args, content) => {
+  // 转义 HTML 标签和部分特殊字符，包括花括号
   const escapeHtmlTags = s => {
     const lookup = {
       '&': '&amp;',
       '"': '&quot;',
       '\'': '&apos;',
       '<': '&lt;',
-      '>': '&gt;'
+      '>': '&gt;',
+      '{': '&#123;',
+      '}': '&#125;'
     }
-    return s.replace(/[&"'<>]/g, c => lookup[c])
+    return s.replace(/[&"'<>{}]/g, c => lookup[c])
   }
-  return `<div class="abc-music-sheet">${escapeHtmlTags(content)}</div>`
+  
+  const trimmed = content.trim()
+  // 使用六个横线作为分隔符拆分内容
+  const parts = trimmed.split('------')
+  
+  if (parts.length < 2) {
+    // 如果没有分隔符，直接将整个内容作为乐谱内容处理
+    return `<div class="abc-music-sheet">${escapeHtmlTags(trimmed)}</div>`
+  }
+  
+  // 第一部分为参数（JSON 字符串），其余部分作为乐谱内容
+  const paramPart = parts[0].trim()
+  const scorePart = parts.slice(1).join('------').trim()
+  
+  let paramsObj = {}
+  try {
+    paramsObj = JSON.parse(paramPart)
+  } catch (e) {
+    console.error('解析 score 标签中的参数 JSON 失败：', e)
+  }
+  
+  // 使用双引号包裹 data-params 的属性值，确保 JSON 内部的双引号已被转义
+  return `<div class="abc-music-sheet" data-params="${escapeHtmlTags(JSON.stringify(paramsObj))}">
+    ${escapeHtmlTags(scorePart)}
+  </div>`
 }
 
 hexo.extend.tag.register('score', score, { ends: true })
+


### PR DESCRIPTION
Modified the score tag to pass custom options to the abcjs RenderAbc interface. This enhancement enables proper rendering of guitar tablature with custom settings such as instrument tuning, labels, and formatting options.

修改了 外挂标签 `score`，现在可以支持传递RenderAbc 的 options，并且意外发现abcjs已经可以一定程度上支持吉他谱了，部分程度解决了[我提出的issue](https://github.com/jerryc127/hexo-theme-butterfly/issues/1647)。

使用方法如下：

> 在score标签中，如想使用RenderAbc 的 options，需要以**JSON**格式书写，而后以**六个短横线**，即`------`分割，在六个短横线下面写乐谱。如果不采用任何参数，则像原来一样书写乐谱。

以下是一个例子：
```txt
{% score %}
{
  "tablature": [
    {
      "instrument": "guitar",
      "label": "Guitar (%T)",
      "tuning": ["D,", "A,", "D", "G", "A", "d"]
    }
  ],
  "initialClef" : true
}
------
X:1
T: Cooley's
M: 4/4
L: 1/8
R: reel
K: G
|:D2|EB{c}BA B2 EB|~B2 AB dBAG|FDAD BDAD|FDAD dAFD|
|:g2 gd f2 gf|a2 ga b2 ag|FDAD BDAD|FDAD dfaf:|

{% endscore %}
```
以及对应的效果：
![example](https://github.com/user-attachments/assets/84722088-1180-4fe7-9d3e-0e9c3385279c)
