### PR TITLE
Update index.pug

### DIFF
--- a/layout/includes/header/index.pug
+++ b/layout/includes/header/index.pug
@@ -8,7 +8,7 @@
 if !theme.disable_top_img && page.top_img !== false
   case globalPageType
     when 'post'
-      - top_img = page.top_img || page.cover || theme.default_top_img
+      - top_img = page.top_img || url_for(page.cover) || theme.default_top_img
     when 'page'
       - top_img = page.top_img || theme.default_top_img
     when 'tag'


### PR DESCRIPTION
This PR focuses on
This PR optimizes the handling of the page.cover path in the top_img logic. By introducing Hexo's url_for helper function, it ensures that relative paths are correctly parsed into absolute paths based on the site root directory, thus preventing image loading issues.

Problem Background
The original code directly used page.cover without processing the path. If page.cover is a relative path (e.g., images/cover.jpg), it may result in image loading failures.

Example
In Hexo, page.cover is a relative path (e.g., /images/1.png) because it is parsed as a relative path in indexPostUI. Using the url_for helper function, the path will be resolved into an absolute path based on the site root directory (e.g., /blog/images/1.png). The original code directly used /images/1.png, which could lead to image loading failures.