### PR TITLE
导航栏常驻时文字标题选择性显示

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@ nav:
   # Navigation bar logo image
   logo:
   display_title: true
+  display_page_title: true
   # Whether to fix navigation bar
   fixed: false
 

--- a/layout/includes/header/nav.pug
+++ b/layout/includes/header/nav.pug
@@ -5,7 +5,7 @@ nav#nav
         img.site-icon(src=url_for(theme.nav.logo) alt='Logo')
       if theme.nav.display_title
         span.site-name=config.title
-    if globalPageType === 'post'
+    if globalPageType === 'post' && theme.nav.display_page_title !== false
       a.nav-page-title(href=url_for('/'))
         span.site-name=(page.title || config.title)
   #menus


### PR DESCRIPTION
选择性显示，当不想文章标题显示，只是显示标题，使用display_page_title选择关闭，默认true