### PR TITLE
feat(structured_data): 为网站首页添加结构化数据

### DIFF
--- a/layout/includes/head/structured_data.pug
+++ b/layout/includes/head/structured_data.pug
@@ -1,34 +1,55 @@
-if theme.structured_data && page.layout === 'post'
-  -
-    // use json-ld to add structured data
+if theme.structured_data
+  if page.layout === 'post'
+    -
+      // https://developers.google.com/search/docs/appearance/structured-data/article
 
-    const title = page.title
-    const url = page.permalink
-    const imageVal = page.cover_type === 'img' ? page.cover : theme.avatar.img
-    const image = imageVal ? full_url_for(imageVal) : ''
-    const datePublished = page.date.toISOString()
-    const dateModified = (page.updated || page.date).toISOString()
-    const author = page.copyright_author || config.author
-    const authorHrefVal = page.copyright_author_href || theme.post_copyright.author_href || site.url
-    const authorHref = full_url_for(authorHrefVal)
+      const title = page.title
+      const url = page.permalink
+      const imageVal = page.cover_type === 'img' ? page.cover : theme.avatar.img
+      const image = imageVal ? full_url_for(imageVal) : ''
+      const datePublished = page.date.toISOString()
+      const dateModified = (page.updated || page.date).toISOString()
+      const author = page.copyright_author || config.author
+      const authorHrefVal = page.copyright_author_href || theme.post_copyright.author_href || config.url
+      const authorHref = full_url_for(authorHrefVal)
 
-    const jsonLd = {
-      "@context": "https://schema.org",
-      "@type": "BlogPosting",
-      "headline": title,
-      "url": url,
-      "image": image,
-      "datePublished": datePublished,
-      "dateModified": dateModified,
-      "author": [{
-        "@type": "Person",
-        "name": author,
-        "url": authorHref
-      }]
-    }
+      const jsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": title,
+        "url": url,
+        "image": image,
+        "datePublished": datePublished,
+        "dateModified": dateModified,
+        "author": [{
+          "@type": "Person",
+          "name": author,
+          "url": authorHref
+        }]
+      }
 
-    jsonLdScript = JSON.stringify(jsonLd, null, 2)
-  -
+      jsonLdScript = JSON.stringify(jsonLd, null, 2)
+    -
+
+  else if is_home() && (!page.current || page.current === 1)
+    -
+      // https://developers.google.com/search/docs/appearance/site-names#website
+
+      const baseUrl = config.url;
+      const currentPath = url_for('/');
+      const isRootOrSubdomain = currentPath.split('/').filter(Boolean).length === 0;
+
+      if (isRootOrSubdomain) {
+        const jsonLd = {
+          "@context": "https://schema.org",
+          "@type": "WebSite",
+          "name": config.title,
+          "url": full_url_for('/'),
+        }
+
+        jsonLdScript = JSON.stringify(jsonLd, null, 2)
+      }
+    -
 
   script(type="application/ld+json").
     !{jsonLdScript}


### PR DESCRIPTION
根据[Google 的说法](https://developers.google.com/search/docs/appearance/site-names)，向首页添加「WebSite 结构化数据」，可以帮助识别网站名称。同时考虑到「Google 搜索不支持子目录级别的网站名称」以及「结构化数据必须放置在网站的首页上」，故仅当首页为「网域级首页」，且页面为第一分页时，添加此结构化数据。

通过[架构标记验证器](https://validator.schema.org/)的测试，生成的结构化数据应该没有问题。