### PR TITLE
在`©`后添加空格

### DIFF
--- a/layout/includes/footer.pug
+++ b/layout/includes/footer.pug
@@ -20,11 +20,12 @@ if nav
     if owner.enable
       - const currentYear = new Date().getFullYear()
       - const sinceYear = owner.since
+      - // Put a non breaking space after the copyright symbol to make good sense semantically, see https://practicaltypography.com/trademark-and-copyright-symbols.html
       span.copyright
         if sinceYear && sinceYear != currentYear
-          != `&copy;${sinceYear} - ${currentYear} By ${config.author}`
+          != `&copy;&nbsp;${sinceYear} - ${currentYear} By ${config.author}`
         else
-          != `&copy;${currentYear} By ${config.author}`
+          != `&copy;&nbsp;${currentYear} By ${config.author}`
     if copyright.enable
       - const v = copyright.version ? getVersion() : false
       span.framework-info


### PR DESCRIPTION
根据[Stack Exchange](https://ux.stackexchange.com/questions/50875/should-there-be-a-space-after-the-copyright-symbol)和[Practical Typography](https://practicaltypography.com/trademark-and-copyright-symbols.html)的说法，在版权符号`©`后添加一个不间断空格，有利于增强语意。同时，像是GitHub、OpenAI等网站，其页脚的`©`后也有空格。故我认为添加空格应该更合适。