### PR TITLE
fix(gitalk): 修复 MD5 函数导致的评论聚合问题

### DIFF
--- a/scripts/helpers/page.js
+++ b/scripts/helpers/page.js
@@ -48,7 +48,7 @@ hexo.extend.helper.register('urlNoIndex', function (url = null, trailingIndex = 
 })
 
 hexo.extend.helper.register('md5', function (path) {
-  return crypto.createHash('md5').update(decodeURI(this.url_for(path))).digest('hex')
+  return crypto.createHash('md5').update(decodeURI(this.url_for(path, {relative: false}))).digest('hex')
 })
 
 hexo.extend.helper.register('injectHtml', data => {


### PR DESCRIPTION
- 修改 url_for 调用添加 {relative: false} 参数
- 解决空字符串 MD5 导致多页面评论混合的问题