### PR TITLE
feat(structured_data): add `alternateNames` for backup

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1033,7 +1033,11 @@ Open_Graph_meta:
 
 # Structured Data
 # https://developers.google.com/search/docs/guides/intro-structured-data
-structured_data: true
+structured_data:
+  enable: true
+  # Alternate name for the site, used in structured data
+  # Format: ['name1', 'name2']
+  alternate_name:
 
 # Add the vendor prefixes to ensure compatibility
 css_prefix: true

--- a/layout/includes/head/structured_data.pug
+++ b/layout/includes/head/structured_data.pug
@@ -40,10 +40,22 @@ if theme.structured_data
       const isRootOrSubdomain = currentPath.split('/').filter(Boolean).length === 0;
 
       if (isRootOrSubdomain) {
+        const domain = new URL(config.url).hostname;
+        const alternateNames = theme.structured_data.alternate_name || [];
+
+        if (config.subtitle) {
+          alternateNames.push(config.subtitle);
+        }
+
+        if (domain) {
+          alternateNames.push(domain);
+        }
+
         const jsonLd = {
           "@context": "https://schema.org",
           "@type": "WebSite",
           "name": config.title,
+          "alternateName": alternateNames,
           "url": full_url_for('/'),
         }
 

--- a/scripts/events/merge_config.js
+++ b/scripts/events/merge_config.js
@@ -574,7 +574,10 @@ hexo.extend.filter.register('before_generate', () => {
       enable: true,
       option: null
     },
-    structured_data: true,
+    structured_data: {
+      enable: true,
+      alternate_name: null
+    },
     css_prefix: true,
     inject: {
       head: null,


### PR DESCRIPTION
[根据Google文档](https://developers.google.com/search/docs/appearance/site-names#alternative)，可以为网站添加备用名称。Google若不选择首选网站名称，可以选择备用的网站名称。程序会自动添加「subtitle」和网站域名两个默认值。用户也可在配置中自行添加相应的备用名称，且权重高于自动生成的名称。