### PR TITLE
feat(umami): 支持自定义脚本名称

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -694,6 +694,7 @@ umami_analytics:
   enable: false
   # For self-hosted setups, configure the hostname of the Umami instance
   serverURL:
+  script_name: script.js
   website_id:
   option:
   UV_PV:

--- a/layout/includes/third-party/umami_analytics.pug
+++ b/layout/includes/third-party/umami_analytics.pug
@@ -1,4 +1,4 @@
-- let { serverURL, website_id, option, UV_PV } = theme.umami_analytics
+- let { serverURL, script_name, website_id, option, UV_PV } = theme.umami_analytics
 - const isServerURL = !!serverURL
 - const baseURL = serverURL ? serverURL.replace(/\/$/, '') : 'https://cloud.umami.is'
 - const apiUrl = serverURL ? serverURL.replace(/\/$/, '') + '/api' : 'https://api.umami.is/v1'
@@ -13,7 +13,7 @@ script.
     }
 
     const loadUmamiJS = () => {
-      btf.getScript('!{baseURL}/script.js', {
+      btf.getScript('!{baseURL}/!{script_name}', {
         'data-website-id': '!{website_id}',
         'data-auto-track': 'false',
         ...option

--- a/scripts/common/default_config.js
+++ b/scripts/common/default_config.js
@@ -400,6 +400,7 @@ module.exports = {
   umami_analytics: {
     enable: false,
     serverURL: null,
+    script_name: 'script.js',
     website_id: null,
     option: null,
     UV_PV: {


### PR DESCRIPTION
Umami支持[通过`TRACKER_SCRIPT_NAME`环境变量自定义脚本名称](https://umami.is/docs/environment-variables#tracker_script_name)，因此可将原先硬编码的`script.js`改为可自定义的选项