### PR TITLE
fix(Pjax): 增加错误处理以防止Pjax失效

### DIFF
--- a/layout/includes/third-party/pjax.pug
+++ b/layout/includes/third-party/pjax.pug
@@ -29,7 +29,13 @@ script.
 
     const triggerPjaxFn = (val) => {
       if (!val) return
-      Object.values(val).forEach(fn => fn())
+      Object.values(val).forEach(fn => {
+        try {
+          fn()
+        } catch (err) {
+          console.debug('Pjax callback failed:', err)
+        }
+      })
     }
 
     document.addEventListener('pjax:send', () => {


### PR DESCRIPTION
先前`uBlock filters – Privacy`过滤规则中添加了`||umami.*/script.js|$script`，会将`umami`的统计脚本拦截。而若umami脚本未加载，则Pjax在执行`triggerPjaxFn`函数时会出错。采用`try-catch`捕获异常即可解决此问题。

Close #1731 