### PR TITLE
fix(lazyload): 支持无引号src属性

### DIFF
--- a/scripts/filters/post_lazyload.js
+++ b/scripts/filters/post_lazyload.js
@@ -18,18 +18,17 @@ const lazyload = htmlContent => {
 
   const bg = hexo.theme.config.lazyload.placeholder ? urlFor(hexo.theme.config.lazyload.placeholder) : 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
 
-  // Use more precise replacement: handle src attributes with double and single quotes, but avoid replacing content inside script tags
+  // Use more precise replacement: handle src attributes with double, single and no quotes, but avoid replacing content inside script tags
   let result = htmlContent
 
-  // Handle src attributes with double quotes
-  result = result.replace(/(<img(?![^>]*?\bdata-lazy-src=)(?:\s[^>]*?)?\ssrc="([^"]+)")(?![^<]*<\/script>)/gi, (match, tag, src) => {
-    return tag.replace(`src="${src}"`, `src="${bg}" data-lazy-src="${src}"`)
-  })
-
-  // Handle src attributes with single quotes
-  result = result.replace(/(<img(?![^>]*?\bdata-lazy-src=)(?:\s[^>]*?)?\ssrc='([^']+)')(?![^<]*<\/script>)/gi, (match, tag, src) => {
-    return tag.replace(`src='${src}'`, `src='${bg}' data-lazy-src='${src}'`)
-  })
+  // Handle src attributes
+  result = result.replace(
+    /(<img(?![^>]*?\bdata-lazy-src=)(?:\s[^>]*?)?\s)src=(?:"([^"]+)"|'([^']+)'|([^\s"'>]+))(?=[^>]*>)(?![^<]*<\/script>)/gi,
+    (match, prefix, dq, sq, uq) => {
+      const src = dq || sq || uq
+      return `${prefix}src="${bg}" data-lazy-src="${src}"`
+    }
+  )
 
   return result
 }


### PR DESCRIPTION
先前的实现中，只支持双引号和单引号的src属性。但是，[`hexo-minify`](https://github.com/lete114/hexo-minify)会压缩HTML，将属性的引号删除。这会导致懒加载失效。因此，我添加了对于无引号src属性的匹配。

<s>此外，由于担心误批评，我先将`script`、`noscript`、`template`等块提取出来，再在剩下的HTML中替换，最后再将块还原，这样应该就没有错误匹配的风险了。</s>考虑到「说说」界面的内容由js渲染，若按前述方法处理，则对说说页面无法生效，故仍沿用原有的正则表达式。