### PR TITLE
fix: 修复搜索结果排版错误

### DIFF
--- a/source/css/_search/index.styl
+++ b/source/css/_search/index.styl
@@ -74,6 +74,7 @@
     .local-search-hit-item,
     .ais-Hits-item
       display: flex
+      flex-direction: column
       align-items: flex-start
       margin: 3px 0
       line-height: 1.8


### PR DESCRIPTION
通过向 `.local-search-hit-item` 添加 `flex-direction: column` 修复在 `top_n_per_article` 设置大于 1 时，搜索结果中同一文章结果排版方向错误的问题。

Fixes #1742.
