### PR TITLE
fix(umami): adapt umami v3

### DIFF
--- a/layout/includes/third-party/umami_analytics.pug
+++ b/layout/includes/third-party/umami_analytics.pug
@@ -31,7 +31,7 @@ script.
     const getData = async (isPost) => {
       try {
         const now = Date.now()
-        const keyUrl = isPost ? `&url=${window.location.pathname}` : ''
+        const keyUrl = isPost ? `&path=${window.location.pathname}` : ''
         const headerList = { 'Accept': 'application/json' }
 
         if (!{isServerURL}) {
@@ -62,8 +62,8 @@ script.
           const pagePV = document.getElementById('umamiPV')
           if (pagePV) {
             const data = await getData(true)
-            if (data && data.pageviews && typeof data.pageviews.value !== 'undefined') {
-              pagePV.textContent = data.pageviews.value
+            if (data && data.pageviews) {
+              pagePV.textContent = data.pageviews
             } else {
               console.warn('Umami Analytics: Invalid page view data received')
             }
@@ -75,8 +75,8 @@ script.
 
           if (config.site_uv) {
             const siteUV = document.getElementById('umami-site-uv')
-            if (siteUV && data && data.visitors && typeof data.visitors.value !== 'undefined') {
-              siteUV.textContent = data.visitors.value
+            if (siteUV && data && data.visitors) {
+              siteUV.textContent = data.visitors
             } else if (siteUV) {
               console.warn('Umami Analytics: Invalid site UV data received')
             }
@@ -84,8 +84,8 @@ script.
 
           if (config.site_pv) {
             const sitePV = document.getElementById('umami-site-pv')
-            if (sitePV && data && data.pageviews && typeof data.pageviews.value !== 'undefined') {
-              sitePV.textContent = data.pageviews.value
+            if (sitePV && data && data.pageviews) {
+              sitePV.textContent = data.pageviews
             } else if (sitePV) {
               console.warn('Umami Analytics: Invalid site PV data received')
             }


### PR DESCRIPTION
Umami升级到了v3版本，一部分内容需要变更。

1. 过滤条件从`url`修改为`path`（参见<https://umami.is/docs/api/website-stats>）。
2. `data`返回值有变化，现在是直接返回数值和字符串，而不是对象。示例如下：
    ```json
    {
        "pageviews": "12151",
        "visitors": 5975,
        "visits": 6711,
        "bounces": 4799,
        "totaltime": "528666",
        "comparison": {
            "pageviews": null,
            "visitors": 0,
            "visits": 0,
            "bounces": null,
            "totaltime": null
        }
    }
    ```
