### PR TITLE
fix: 修复 busuanzi data-pjax src

### DIFF
--- a/layout/includes/additional-js.pug
+++ b/layout/includes/additional-js.pug
@@ -52,7 +52,7 @@ div
     != partial("includes/third-party/umami_analytics", {}, { cache: true })
 
   if theme.busuanzi.site_uv || theme.busuanzi.site_pv || theme.busuanzi.page_pv
-    script(async data-pjax src=url_for(theme.asset.busuanzi) || '//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js')
+    script(async data-pjax src=theme.asset.busuanzi || '//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js')
 
   != partial('includes/third-party/search/index', {}, { cache: true })
 

--- a/layout/includes/additional-js.pug
+++ b/layout/includes/additional-js.pug
@@ -52,7 +52,7 @@ div
     != partial("includes/third-party/umami_analytics", {}, { cache: true })
 
   if theme.busuanzi.site_uv || theme.busuanzi.site_pv || theme.busuanzi.page_pv
-    script(async data-pjax src=theme.asset.busuanzi || '//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js')
+    script(async data-pjax src=theme.asset.busuanzi ? url_for(theme.asset.busuanzi) : '//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js')
 
   != partial('includes/third-party/search/index', {}, { cache: true })
 


### PR DESCRIPTION
fix #1762

我注意到您在 439014bbb625e80418d60f3a9d4ddc1111aba920 中做出了如下更改：

https://github.com/jerryc127/hexo-theme-butterfly/commit/439014bbb625e80418d60f3a9d4ddc1111aba920#diff-ae43f25199f81a689bba59149d53bf24b63ba736145353a762e15097a48cb84fL55-R55

原本，当 `theme.asset.busuanzi` 是个空值时，那最终的 `src` 就会回退成默认的 `'//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js'`，那一切就是正常的

根据 [hexo-util 文档](https://github.com/hexojs/hexo-util?tab=readme-ov-file#url_forpath-option)，`url_for` 函数会给传入的路径加上根目录前缀，于是，`src` 的值就变成了 `/`，造成 `Uncaught SyntaxError: Unexpected token '<'` 错误

我认为这个 `url_for` 加得是没有必要的，因为 `theme.asset.busuanzi` 是个 CDN 链接，不需要为其做根目录的处理

（我说我计数怎么全寄了，还以为是被墙了）