### PR TITLE
Allow to set specific post pagination cover

### DIFF
--- a/layout/includes/pagination.pug
+++ b/layout/includes/pagination.pug
@@ -19,7 +19,7 @@ if page.total !== 1
 
           a.pagination-related(class=className href=url_for(direction.path) title=direction.title)
             if direction.cover_type === 'img'
-              img.cover(src=url_for(direction.cover) onerror=`onerror=null;src='${url_for(theme.error_img.post_page)}'` alt=`cover of ${key === 'prev' ? 'previous' : 'next'} post`)
+                img.cover(src=url_for(direction.pagination_cover || direction.cover) onerror=`onerror=null;src='${url_for(theme.error_img.post_page)}'` alt=`cover of ${key === 'prev' ? 'previous' : 'next'} post`)
             else
               .cover(style=`background: ${direction.cover || 'var(--default-bg-color)'}`)
 

--- a/scripts/filters/random_cover.js
+++ b/scripts/filters/random_cover.js
@@ -34,7 +34,7 @@ hexo.extend.generator.register('post', locals => {
 
   const handleImg = data => {
     const imgTestReg = /\.(png|jpe?g|gif|svg|webp|avif)(\?.*)?$/i
-    let { cover: coverVal, top_img: topImg } = data
+    let { cover: coverVal, top_img: topImg, pagination_cover: paginationCover } = data
 
     // Add path to top_img and cover if post_asset_folder is enabled
     if (hexo.config.post_asset_folder) {
@@ -43,6 +43,9 @@ hexo.extend.generator.register('post', locals => {
       }
       if (coverVal && coverVal.indexOf('/') === -1 && imgTestReg.test(coverVal)) {
         data.cover = `${data.path}${coverVal}`
+      }
+      if (paginationCover && paginationCover.indexOf('/') === -1 && imgTestReg.test(paginationCover)) {
+        data.pagination_cover = `${data.path}${paginationCover}`
       }
     }
 


### PR DESCRIPTION
Many times, the image used as the next/prev post card (which is the cover by default) doesn't fit well with the elongated layout of those cards. This change allows using `pagination_cover: test.png` to set a specific image without modifying the main cover, providing more flexibility and better styling, if pagination_cover isn't set the cover will be taken like the normal flow.

P.S.: I'm not Chinese, so it's quite difficult for me to search through the discussions and PRs to see if something like this has already been talked about. I'm also not a developer, so my knowledge of these technologies is fairly limited, but I believe this change is simple and functional. Thank you for this awesome theme.