### PR TITLE
Add support for a dedicated recent_post_cover in the Recent Posts card widget

### DIFF
--- a/layout/includes/widget/card_recent_post.pug
+++ b/layout/includes/widget/card_recent_post.pug
@@ -9,15 +9,17 @@ if theme.aside.card_recent_post.enable
       - site.posts.sort(sort, -1).limit(postLimit).each(function(article){
         - let link = article.link || article.path
         - let title = article.title || _p('no_title')
-        - let no_cover = article.cover === false || !theme.cover.aside_enable ? 'no-cover' : ''
-        - let post_cover = article.cover
+        - let has_recent_post_cover = article.recent_post_cover !== undefined
+        - let effective_cover = has_recent_post_cover ? article.recent_post_cover : article.cover
+        - let effective_cover_type = has_recent_post_cover ? article.recent_post_cover_type : article.cover_type
+        - let no_cover = effective_cover === false || !theme.cover.aside_enable ? 'no-cover' : ''
         .aside-list-item(class=no_cover)
-          if post_cover && theme.cover.aside_enable
+          if effective_cover && theme.cover.aside_enable
             a.thumbnail(href=url_for(link) title=title)
-              if article.cover_type === 'img'
-                img(src=url_for(post_cover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title)
+              if effective_cover_type === 'img'
+                img(src=url_for(effective_cover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title)
               else
-                div(style=`background: ${post_cover}`)
+                div(style=`background: ${effective_cover}`)
           .content
             a.title(href=url_for(link) title=title)= title
             if theme.aside.card_recent_post.sort === 'updated'

--- a/scripts/filters/random_cover.js
+++ b/scripts/filters/random_cover.js
@@ -41,7 +41,11 @@ hexo.extend.generator.register('post', locals => {
   const coverGenerator = createCoverGenerator()
 
   const handleImg = data => {
-    let { cover: coverVal, top_img: topImg, pagination_cover: paginationCover } = data
+    let { cover: coverVal, top_img: topImg, pagination_cover: paginationCover, recent_post_cover: recentPostCover } = data
+
+    if (recentPostCover === '' || recentPostCover === null) {
+      data.recent_post_cover = recentPostCover = false
+    }
 
     // Add path to top_img and cover if post_asset_folder is enabled
     if (postAssetFolder) {
@@ -54,6 +58,13 @@ hexo.extend.generator.register('post', locals => {
       if (paginationCover && paginationCover.indexOf('/') === -1 && imgTestReg.test(paginationCover)) {
         data.pagination_cover = `${data.path}${paginationCover}`
       }
+      if (recentPostCover && recentPostCover.indexOf('/') === -1 && imgTestReg.test(recentPostCover)) {
+        data.recent_post_cover = recentPostCover = `${data.path}${recentPostCover}`
+      }
+    }
+
+    if (recentPostCover && (recentPostCover.indexOf('//') !== -1 || imgTestReg.test(recentPostCover))) {
+      data.recent_post_cover_type = 'img'
     }
 
     if (coverVal === false) return data


### PR DESCRIPTION
## PR Motivation
In the current workflow, when the Recent Posts sidebar widget is enabled, it always uses the post’s main cover. Since this widget is meant to act as a small, quick entry point to the latest posts, reusing the main cover isn’t ideal: once resized to thumbnail size, the image often becomes too small to appreciate its details. This change allows defining a dedicated recent_post_cover that is custom and independent from the main cover.

## Changes
- Adds per-post recent_post_cover frontmatter support to override the cover shown in the Recent Posts card (without affecting the post’s main cover).
- Allows disabling the Recent Posts cover via recent_post_cover: false (empty/null are treated as disabled too) following [documentation](https://butterfly.js.org/en/posts/butterfly-docs-en-theme-pages/#Post-Front-matter) for post cover “_Cover: [Optional] Article cover (If top_img is not set, the cover will be displayed at the top of the article. Can be set to false/image address/empty)_”.
- Supports post_asset_folder path handling for recent_post_cover image filenames.
- Detects recent_post_cover type independently from the post cover_type (image vs background), enabling mixed combinations (CSS background + image) and correct thumbnail rendering.
- Preserves existing behavior when recent_post_cover is not defined (falls back to cover).

## Visual Examples:

### Current Workflow:
<img width="1613" height="565" alt="default_workflow" src="https://github.com/user-attachments/assets/e9c7e2fe-b20b-4317-8b8a-3a2744a9f236" />

### With PR Changes

Allow cover and recent_post_cover to be independen
<img width="1625" height="904" alt="custom_recent_post_cover" src="https://github.com/user-attachments/assets/5df885f3-ca8f-48b9-8790-cad246b5b74e" />

Keep cover enabled while disabling recent_post_cover
<img width="1622" height="542" alt="disable_recent_cover" src="https://github.com/user-attachments/assets/938d8e60-2c8c-4157-9a33-87208fcd1283" />

Support disabling cover while keeping recent_post_cover enabled
<img width="1584" height="566" alt="only_recent_post_cover" src="https://github.com/user-attachments/assets/d27ef17e-e02f-4dc6-8c91-2b986bc358a1" />

Support image cover with a CSS background-color recent_post_cover
<img width="1582" height="569" alt="color_and_img_independent_invert" src="https://github.com/user-attachments/assets/8627197d-efdd-4724-b3f6-c5a93dd47ef6" />

Support CSS background-color cover with an image recent_post_cover
<img width="1590" height="570" alt="color_and_img_independent" src="https://github.com/user-attachments/assets/9211b770-f132-4e43-a495-f47cbd715d7a" />

Fall back to cover when recent_post_cover is not set, preserving the current workflow
<img width="1613" height="565" alt="default_workflow" src="https://github.com/user-attachments/assets/8cb84929-c4e4-4837-9a28-4f70a296ab7a" />

P.S.: I'm not Chinese, so it's quite difficult for me to search through the discussions and PRs to see if something like this has already been talked about. I'm also not a developer, so my knowledge of these technologies is fairly limited, but I believe this change is simple and functional. Thank you for this awesome theme.