### PR TITLE
chore: use `text-autospace` by default

### DIFF
--- a/source/css/_global/index.styl
+++ b/source/css/_global/index.styl
@@ -107,6 +107,7 @@ body
   font-size: var(--global-font-size)
   font-family: $font-family
   line-height: $text-line-height
+  text-autospace: normal
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0)
   scroll-behavior: smooth
 


### PR DESCRIPTION
顺带把中文里手动在数字和中文间的空格删掉了。如果觉得链接前后需要添加间隙的话，我建议是通过CSS实现，而非手动添加空格。

Close #1775 