### PR TITLE
feat(cloudTags): add custom colors support for cloudTags on card_tags widget & tags page Pr_Satus(Finished)

### DIFF
--- a/layout/includes/page/tags.pug
+++ b/layout/includes/page/tags.pug
@@ -1,3 +1,2 @@
-- let { colormode, custom_colors } = theme.aside.card_tags
 .tag-cloud-list.text-center
-  !=cloudTags({source: site.tags, orderby: page.orderby || 'random', order: page.order || 1, minfontsize: 1.2, maxfontsize: 1.5, limit: 0, unit: 'em', colormode: colormode, custom_colors: custom_colors})
+  !=cloudTags({source: site.tags, orderby: page.orderby || 'random', order: page.order || 1, minfontsize: 1.2, maxfontsize: 1.5, limit: 0, unit: 'em', custom_colors: page.custom_colors})

--- a/layout/includes/page/tags.pug
+++ b/layout/includes/page/tags.pug
@@ -1,2 +1,3 @@
+- let { colormode, custom_colors } = theme.aside.card_tags
 .tag-cloud-list.text-center
-  !=cloudTags({source: site.tags, orderby: page.orderby || 'random', order: page.order || 1, minfontsize: 1.2, maxfontsize: 1.5, limit: 0, unit: 'em', colormode: page.colormode, custom_colors: page.custom_colors})
+  !=cloudTags({source: site.tags, orderby: page.orderby || 'random', order: page.order || 1, minfontsize: 1.2, maxfontsize: 1.5, limit: 0, unit: 'em', colormode: colormode, custom_colors: custom_colors})

--- a/layout/includes/page/tags.pug
+++ b/layout/includes/page/tags.pug
@@ -1,2 +1,2 @@
 .tag-cloud-list.text-center
-  !=cloudTags({source: site.tags, orderby: page.orderby || 'random', order: page.order || 1, minfontsize: 1.2, maxfontsize: 1.5, limit: 0, unit: 'em'})
+  !=cloudTags({source: site.tags, orderby: page.orderby || 'random', order: page.order || 1, minfontsize: 1.2, maxfontsize: 1.5, limit: 0, unit: 'em', colormode: page.colormode, custom_colors: page.custom_colors})

--- a/layout/includes/widget/card_tags.pug
+++ b/layout/includes/widget/card_tags.pug
@@ -5,10 +5,10 @@ if theme.aside.card_tags.enable
         i.fas.fa-tags
         span= _p('aside.card_tags')
 
-      - let { limit, orderby, order } = theme.aside.card_tags
+      - let { limit, orderby, order, colormode, custom_colors } = theme.aside.card_tags
       - limit = limit === 0 ? 0 : limit || 40
 
       if theme.aside.card_tags.color
-        .card-tag-cloud!= cloudTags({source: site.tags, orderby: orderby, order: order, minfontsize: 1.15, maxfontsize: 1.45, limit: limit, unit: 'em', page: 'index'})
+        .card-tag-cloud!= cloudTags({source: site.tags, orderby: orderby, order: order, minfontsize: 1.15, maxfontsize: 1.45, limit: limit, unit: 'em', page: 'index', colormode: colormode, custom_colors: custom_colors})
       else
-        .card-tag-cloud!= tagcloud({orderby: orderby, order: order, min_font: 1.1, max_font: 1.5, amount: limit , color: true, start_color: '#999', end_color: '#99a9bf', unit: 'em'})
+        .card-tag-cloud!= tagcloud({orderby: orderby, order: order, min_font: 1.1, max_font: 1.5, amount: limit, color: true, start_color: '#999', end_color: '#99a9bf', unit: 'em'})

--- a/layout/includes/widget/card_tags.pug
+++ b/layout/includes/widget/card_tags.pug
@@ -5,10 +5,10 @@ if theme.aside.card_tags.enable
         i.fas.fa-tags
         span= _p('aside.card_tags')
 
-      - let { limit, orderby, order, colormode, custom_colors } = theme.aside.card_tags
+      - let { limit, orderby, order, custom_colors } = theme.aside.card_tags
       - limit = limit === 0 ? 0 : limit || 40
 
       if theme.aside.card_tags.color
-        .card-tag-cloud!= cloudTags({source: site.tags, orderby: orderby, order: order, minfontsize: 1.15, maxfontsize: 1.45, limit: limit, unit: 'em', page: 'index', colormode: colormode, custom_colors: custom_colors})
+        .card-tag-cloud!= cloudTags({source: site.tags, orderby: orderby, order: order, minfontsize: 1.15, maxfontsize: 1.45, limit: limit, unit: 'em', page: 'index', custom_colors: custom_colors})
       else
         .card-tag-cloud!= tagcloud({orderby: orderby, order: order, min_font: 1.1, max_font: 1.5, amount: limit, color: true, start_color: '#999', end_color: '#99a9bf', unit: 'em'})

--- a/scripts/common/default_config.js
+++ b/scripts/common/default_config.js
@@ -179,6 +179,7 @@ module.exports = {
       enable: true,
       limit: 40,
       color: false,
+      custom_colors: null,
       orderby: 'random',
       order: 1,
       sort_order: null

--- a/scripts/helpers/page.js
+++ b/scripts/helpers/page.js
@@ -19,7 +19,7 @@ hexo.extend.helper.register('postDesc', data => {
 
 hexo.extend.helper.register('cloudTags', function (options = {}) {
   const env = this
-  let { source, minfontsize, maxfontsize, limit, unit = 'px', orderby, order, page = 'tags', colormode, custom_colors } = options
+  let { source, minfontsize, maxfontsize, limit, unit = 'px', orderby, order, page = 'tags', custom_colors } = options
 
   if (limit > 0) {
     source = source.limit(limit)
@@ -60,8 +60,6 @@ hexo.extend.helper.register('cloudTags', function (options = {}) {
 
   const resolveColorClass = (idx) => `tag-color-${idx % userColors.length}`
 
-  const generateSizeStyle = (size, unit) => `font-size: ${parseFloat(size.toFixed(2))}${unit};`
-
   const generateStyle = (size, unit, page, color) => {
     const colorStyle = page === 'tags' ? `background-color: ${color};` : `color: ${color};`
     return `font-size: ${parseFloat(size.toFixed(2))}${unit}; ${colorStyle}`
@@ -71,9 +69,10 @@ hexo.extend.helper.register('cloudTags', function (options = {}) {
     const ratio = length ? sizeMap.get(tag.length) / length : 0
     const size = minfontsize + ((maxfontsize - minfontsize) * ratio)
 
-    if (colormode === 'custom' && userColors && userColors.length) {
+    if (userColors && userColors.length) {
       const colorClass = resolveColorClass(idx)
-      const style = generateSizeStyle(size, unit)
+      const color = userColors[idx % userColors.length]
+      const style = generateStyle(size, unit, page, color)
       return `<a href="${env.url_for(tag.path)}" class="tag-cloud-item ${colorClass}" style="${style}">${tag.name}</a>`
     }
 

--- a/scripts/helpers/page.js
+++ b/scripts/helpers/page.js
@@ -58,13 +58,9 @@ hexo.extend.helper.register('cloudTags', function (options = {}) {
 
   const userColors = normalizeColors(custom_colors)
 
-  const resolveColor = (idx) => {
-    if (colormode === 'custom' && userColors && userColors.length) {
-      if (userColors.length === 1) return userColors[0]
-      return userColors[idx % userColors.length]
-    }
-    return getRandomColor()
-  }
+  const resolveColorClass = (idx) => `tag-color-${idx % userColors.length}`
+
+  const generateSizeStyle = (size, unit) => `font-size: ${parseFloat(size.toFixed(2))}${unit};`
 
   const generateStyle = (size, unit, page, color) => {
     const colorStyle = page === 'tags' ? `background-color: ${color};` : `color: ${color};`
@@ -74,7 +70,14 @@ hexo.extend.helper.register('cloudTags', function (options = {}) {
   return source.sort(orderby, order).map((tag, idx) => {
     const ratio = length ? sizeMap.get(tag.length) / length : 0
     const size = minfontsize + ((maxfontsize - minfontsize) * ratio)
-    const color = resolveColor(idx)
+
+    if (colormode === 'custom' && userColors && userColors.length) {
+      const colorClass = resolveColorClass(idx)
+      const style = generateSizeStyle(size, unit)
+      return `<a href="${env.url_for(tag.path)}" class="tag-cloud-item ${colorClass}" style="${style}">${tag.name}</a>`
+    }
+
+    const color = getRandomColor()
     const style = generateStyle(size, unit, page, color)
     return `<a href="${env.url_for(tag.path)}" style="${style}">${tag.name}</a>`
   }).join('')

--- a/source/css/_page/tags.styl
+++ b/source/css/_page/tags.styl
@@ -89,16 +89,3 @@
 .page-title
   & + .tag-cloud-list
     text-align: left
-
-tag_colors = hexo-config('aside.card_tags.custom_colors')
-
-.tag-cloud-list .tag-cloud-item
-  background-color var(--tag-cloud-color)
-
-.card-tag-cloud .tag-cloud-item
-  color var(--tag-cloud-color)
-
-if tag_colors && length(tag_colors) > 0
-  for c, i in tag_colors
-    .tag-cloud-item.tag-color-{i}
-      --tag-cloud-color convert(c)

--- a/source/css/_page/tags.styl
+++ b/source/css/_page/tags.styl
@@ -89,3 +89,16 @@
 .page-title
   & + .tag-cloud-list
     text-align: left
+
+tag_colors = hexo-config('aside.card_tags.custom_colors')
+
+.tag-cloud-list .tag-cloud-item
+  background-color var(--tag-cloud-color)
+
+.card-tag-cloud .tag-cloud-item
+  color var(--tag-cloud-color)
+
+if tag_colors && length(tag_colors) > 0
+  for c, i in tag_colors
+    .tag-cloud-item.tag-color-{i}
+      --tag-cloud-color convert(c)


### PR DESCRIPTION
# PR Motivation
In the current implementation, both the tags page and the `card_tags` widget (when `color` is enabled) render their tag lists using the `cloudTags` helper, which only allows generating tags with random colors. This can cause visual inconsistencies when users style their site around a specific color palette, breaking overall design consistency.

# PR Summary
This PR adds an optional custom palette mode to the `cloudTags` helper. When `colormode` is set to `custom` and `custom_colors` are provided, `cloudTags` doesnt hardcodes colors inline; instead it assigns cyclic `tag-color-*` classes (repeating once it reaches the end of the palette) and leaves the actual color values to CSS. The palette is read from the theme config and generated in Stylus, which makes it easy to target from CSS. If `colormode` is not set (or isn’t `custom`), the helper remains fully backwards compatible and continues using the existing `getRandomColor()` inline-color behavior. The tags page is also aligned with the same theme configuration used by the `card_tags` widget so both outputs stay consistent.

## Example
## Config
```yml
aside:
  card_tags:
    enable: true
    # If set 0 will show all
    limit: 40
    color: true
    colormode: custom
    custom_colors:
      - "rgb(111, 79, 140)"
      - "rgba(94, 62, 126, 0.9)"
```
## Helper

- Output example:

```html
<a href="/tags/Tag-0" class="tag-cloud-item tag-color-0" style="font-size: 1.5em;">TAG 0</a>
<a href="/tags/Tag-1" class="tag-cloud-item tag-color-1" style="font-size: 1.5em;">TAG 1</a>
```
- Cycles classes using idx % custom_colors.length.
- No inline background-color / color is generated in this mode.
- Default mode (unchanged): still uses getRandomColor() and inline color styles as before.

## Templates

tags.pug now passes colormode and custom_colors from theme config (same source as card_tags).

## Stylus / CSS

- Reads palette from theme config: hexo-config('aside.card_tags.custom_colors')
- Generates .tag-color-* slot classes and maps them to --tag-cloud-color.
- Applies the variable depending on the container:
  - .tag-cloud-list .tag-cloud-item → background-color: var(--tag-cloud-color)
  - .card-tag-cloud .tag-cloud-item → color: var(--tag-cloud-color)

Example output CSS (for illustration):
```css
.tag-cloud-list .tag-cloud-item {
  background-color: var(--tag-cloud-color);
}
.card-tag-cloud .tag-cloud-item {
  color: var(--tag-cloud-color);
}
.tag-cloud-item.tag-color-0 {
  --tag-cloud-color: #6f4f8c;
}
.tag-cloud-item.tag-color-1 {
  --tag-cloud-color: rgba(94,62,126,0.9);
}
```
# Documentation Suggestion
## card_tags Widget (Aside)
[Current Docs](https://butterfly.js.org/en/posts/butterfly-docs-en-theme-config/?highlight=card_tag#Aside)

I suggest updating the `card_tags` section by adding `card_tags.colormode` and `card_tags.custom_colors`:

Syntax | Explanation
-- | --
card_tags.enable | Whether to display the tags card
card_tags.limit | Number of tags to display, 0 for all
card_tags.color | Whether to display tag colors.
card_tags.orderby | Tag sorting method: random / name / length
card_tags.order | Sorting method, 1 for ascending, -1 for descending
card_tags.colormode | [Optional] Color mode for tags when `card_tags.color: true`. Set to `custom` to use user-defined colors. If not set (or set to random), random colors are used.
card_tags.custom_colors | [Optional] Custom colors used when `card_tags.colormode: custom`. Accepts a single color string (applies the same color to all tags) or a YAML sequence (block sequence using `-` or flow sequence using `[...]`) to cycle colors repeatedly. Note: Hex colors must be quoted in YAML (since `#` starts a comment).

# Visual Examples
## Current Workflow
### Aside card_tags
#### Color False
<img width="671" height="208" alt="aside_tags_yaml_old_workflow" src="https://github.com/user-attachments/assets/16503f72-36e7-4066-be21-b1918b53c45c" />
<img width="1692" height="1053" alt="render_aside_tags_yaml_old_workflow" src="https://github.com/user-attachments/assets/a1355bfb-6b1b-4978-be08-a8c2305ed9e5" />

#### Color True
<img width="695" height="208" alt="aside_tags_color_true_yaml_old_workflow" src="https://github.com/user-attachments/assets/cf9b1be2-72f7-4f0e-85c3-22a49e834536" />
<img width="1597" height="1109" alt="render_aside_tags_color_old_workflow" src="https://github.com/user-attachments/assets/67becf24-74d9-4683-9770-25ecc0be9800" />
<img width="1447" height="685" alt="default_workflow" src="https://github.com/user-attachments/assets/09ae4568-3fcf-4a9e-8422-638ac39de781" />


## With PR Changes
### Aside card_tags
#### Colormode Custom
<img width="677" height="377" alt="aside_tags_color_custom_yaml" src="https://github.com/user-attachments/assets/3de8c69a-9b98-47d6-9b99-d5220f527f33" />
<img width="1236" height="836" alt="render_aside_tags_color_custom" src="https://github.com/user-attachments/assets/3918e8c6-9a40-4efb-a076-520e8009c5aa" />
<img width="1449" height="685" alt="render_array_custom_colors" src="https://github.com/user-attachments/assets/eea87dc6-4ad3-4fd6-9c26-7095f98829e9" />

#### Colormode random
<img width="680" height="377" alt="aside_tags_colormode_random_yaml" src="https://github.com/user-attachments/assets/65073fa8-9c27-408e-95b8-a310e351f54c" />
<img width="1225" height="834" alt="render_aside_tags_colormode_random" src="https://github.com/user-attachments/assets/ed711d40-53ff-4ac7-b0fb-ef557aec1990" />

#### Color False (Preserves the existing workflow.)
<img width="697" height="377" alt="aside_tags_color_false_yaml" src="https://github.com/user-attachments/assets/990f3817-497f-4405-8c79-39f066809898" />
<img width="1287" height="817" alt="render_aside_tags_color_false" src="https://github.com/user-attachments/assets/96251998-e64b-4de0-92d4-7f87e5fa68d6" />



P.S.: I'm not Chinese, so it's quite difficult for me to search through the discussions and PRs to see if something like this has already been talked about. I'm also not a developer, so my knowledge of these technologies is fairly limited, but I believe this change is useful. Thank you for this awesome theme.
