### PR TITLE
优化页面标题过长显示的问题

### DIFF
--- a/source/css/_layout/head.styl
+++ b/source/css/_layout/head.styl
@@ -37,12 +37,8 @@
     margin: 0
     color: var(--white)
     font-size: 1.85em
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 3;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    word-break: break-word;
+    @extend .limit-more-line
+    -webkit-line-clamp: 3
 
     +minWidth768()
       font-size: 2.85em
@@ -468,3 +464,4 @@
         opacity: 0
 
         transform: translateY(10px)
+

--- a/source/css/_layout/head.styl
+++ b/source/css/_layout/head.styl
@@ -37,6 +37,12 @@
     margin: 0
     color: var(--white)
     font-size: 1.85em
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-word;
 
     +minWidth768()
       font-size: 2.85em
@@ -460,4 +466,5 @@
 
       & > :first-child
         opacity: 0
+
         transform: translateY(10px)


### PR DESCRIPTION
<img width="1131" height="558" alt="image" src="https://github.com/user-attachments/assets/527429b0-0415-461a-a732-e9d291da890f" />

### 优化后
<img width="1150" height="518" alt="image" src="https://github.com/user-attachments/assets/23acd514-9c3b-463e-bb71-e525f9219145" />
