### PR TITLE
feat: Video covers support + fetchpriority tuning for LCP covers

### DIFF
--- a/layout/includes/mixins/article-sort.pug
+++ b/layout/includes/mixins/article-sort.pug
@@ -21,7 +21,7 @@ mixin articleSort(posts)
             - const coverVideoParameters = article.cover_video_parameters || {}
             - const autoplay = hasArticleSortCover ? articleSortVideoParameters.autoplay : (articleSortVideoParameters.autoplay ?? coverVideoParameters.autoplay)
             - const loop = hasArticleSortCover ? articleSortVideoParameters.loop : (articleSortVideoParameters.loop ?? coverVideoParameters.loop)
-            - const poster = hasArticleSortCover ? articleSortVideoParameters.article_sort_video_poster : (articleSortVideoParameters.article_sort_video_poster ?? coverVideoParameters.cover_video_poster)
+            - const poster = hasArticleSortCover ? articleSortVideoParameters.poster : (articleSortVideoParameters.poster ?? coverVideoParameters.poster)
             if coverType === 'video'
               video(autoplay=autoplay loop=loop muted playsinline poster=poster ? url_for(poster) : undefined)
                 source(src=url_for(cover) type=coverMime || undefined)

--- a/layout/includes/mixins/article-sort.pug
+++ b/layout/includes/mixins/article-sort.pug
@@ -3,28 +3,32 @@ mixin articleSort(posts)
     - let year
     - posts.forEach((article, index) => {
       - const tempYear = date(article.date, 'YYYY')
-      - const postCover = article.article_sort_cover === false ? false : (article.article_sort_cover || article.cover)
-      - const noCoverClass = postCover === false || !theme.cover.archives_enable ? 'no-article-cover' : ''
+      - const hasArticleSortCover = article.article_sort_cover !== undefined
+      - const cover = hasArticleSortCover ? (article.article_sort_cover === false ? false : article.article_sort_cover) : article.cover
+      - const noCoverClass = cover === false || !theme.cover.archives_enable ? 'no-article-cover' : ''
       - const title = article.title || _p('no_title')
       if tempYear !== year
         - year = tempYear
         .article-sort-item.year= year
       .article-sort-item(class=noCoverClass)
-        if postCover && theme.cover.archives_enable
+        if cover && theme.cover.archives_enable
           a.article-sort-item-img(href=url_for(article.path) title=title)
             - const eagerCoversCount = theme.LCP_Optimization.enable ? (theme.LCP_Optimization.articles_sort_page ?? 0) : 0
             - const isEager = index < eagerCoversCount
-            - const postCoverType = article.article_sort_cover_type || article.cover_type
-            - const postCoverMime = article.article_sort_cover_mime || article.cover_mime
+            - const coverType = hasArticleSortCover ? article.article_sort_cover_type : article.cover_type
+            - const coverMime = hasArticleSortCover ? article.article_sort_cover_mime : article.cover_mime
+            - const articleSortVideoParameters = article.article_sort_video_parameters || {}
             - const coverVideoParameters = article.cover_video_parameters || {}
-            - const postVideoCover = coverVideoParameters.post_video_cover
-            if postCoverType === 'video'
-              video(autoplay=coverVideoParameters.autoplay loop=coverVideoParameters.loop muted playsinline poster=postVideoCover ? url_for(postVideoCover) : undefined)
-                source(src=url_for(postCover) type=postCoverMime)
-            else if postCoverType === 'img'
-              img(src=url_for(postCover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title loading=isEager ? 'eager' : undefined fetchpriority=isEager ? 'high' : undefined decoding=isEager ? undefined : 'async')
+            - const autoplay = hasArticleSortCover ? articleSortVideoParameters.autoplay : (articleSortVideoParameters.autoplay ?? coverVideoParameters.autoplay)
+            - const loop = hasArticleSortCover ? articleSortVideoParameters.loop : (articleSortVideoParameters.loop ?? coverVideoParameters.loop)
+            - const poster = hasArticleSortCover ? articleSortVideoParameters.article_sort_video_poster : (articleSortVideoParameters.article_sort_video_poster ?? coverVideoParameters.cover_video_poster)
+            if coverType === 'video'
+              video(autoplay=autoplay loop=loop muted playsinline poster=poster ? url_for(poster) : undefined)
+                source(src=url_for(cover) type=coverMime || undefined)
+            else if coverType === 'img'
+              img(src=url_for(cover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title loading=isEager ? 'eager' : undefined fetchpriority=isEager ? 'high' : undefined decoding=isEager ? undefined : 'async')
             else
-              div(style=`background: ${postCover}`)
+              div(style=`background: ${cover}`)
         .article-sort-item-info
           .article-sort-item-time
             i.far.fa-calendar-alt

--- a/layout/includes/mixins/article-sort.pug
+++ b/layout/includes/mixins/article-sort.pug
@@ -3,28 +3,28 @@ mixin articleSort(posts)
     - let year
     - posts.forEach((article, index) => {
       - const tempYear = date(article.date, 'YYYY')
-      - const post_cover = article.article_sort_cover === false ? false : (article.article_sort_cover || article.cover)
-      - const noCoverClass = post_cover === false || !theme.cover.archives_enable ? 'no-article-cover' : ''
+      - const postCover = article.article_sort_cover === false ? false : (article.article_sort_cover || article.cover)
+      - const noCoverClass = postCover === false || !theme.cover.archives_enable ? 'no-article-cover' : ''
       - const title = article.title || _p('no_title')
       if tempYear !== year
         - year = tempYear
         .article-sort-item.year= year
       .article-sort-item(class=noCoverClass)
-        if post_cover && theme.cover.archives_enable
+        if postCover && theme.cover.archives_enable
           a.article-sort-item-img(href=url_for(article.path) title=title)
             - const eagerCoversCount = theme.LCP_Optimization.enable ? (theme.LCP_Optimization.articles_sort_page ?? 0) : 0
             - const isEager = index < eagerCoversCount
-            - const post_cover_type = article.article_sort_cover_type || article.cover_type
-            - const post_cover_mime = article.article_sort_cover_mime || article.cover_mime
-            - const cover_video_parameters = article.cover_video_parameters || {}
-            - const post_video_cover = cover_video_parameters.post_video_cover
-            if post_cover_type === 'video'
-              video(autoplay=cover_video_parameters.autoplay loop=cover_video_parameters.loop muted playsinline poster=post_video_cover ? url_for(post_video_cover) : undefined)
-                source(src=url_for(post_cover) type=post_cover_mime)
-            else if post_cover_type === 'img'
-              img(src=url_for(post_cover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title loading=isEager ? 'eager' : undefined fetchpriority=isEager ? 'high' : undefined decoding=isEager ? undefined : 'async')
+            - const postCoverType = article.article_sort_cover_type || article.cover_type
+            - const postCoverMime = article.article_sort_cover_mime || article.cover_mime
+            - const coverVideoParameters = article.cover_video_parameters || {}
+            - const postVideoCover = coverVideoParameters.post_video_cover
+            if postCoverType === 'video'
+              video(autoplay=coverVideoParameters.autoplay loop=coverVideoParameters.loop muted playsinline poster=postVideoCover ? url_for(postVideoCover) : undefined)
+                source(src=url_for(postCover) type=postCoverMime)
+            else if postCoverType === 'img'
+              img(src=url_for(postCover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title loading=isEager ? 'eager' : undefined fetchpriority=isEager ? 'high' : undefined decoding=isEager ? undefined : 'async')
             else
-              div(style=`background: ${post_cover}`)
+              div(style=`background: ${postCover}`)
         .article-sort-item-info
           .article-sort-item-time
             i.far.fa-calendar-alt

--- a/layout/includes/mixins/article-sort.pug
+++ b/layout/includes/mixins/article-sort.pug
@@ -12,16 +12,18 @@ mixin articleSort(posts)
         .article-sort-item.year= year
       .article-sort-item(class=noCoverClass)
         if cover && theme.cover.archives_enable
+          - const eagerCoversCount = theme.LCP_Optimization.enable ? (theme.LCP_Optimization.articles_sort_page ?? 0) : 0
+          - const isEager = index < eagerCoversCount
+          - const coverType = hasArticleSortCover ? article.article_sort_cover_type : article.cover_type
+          - const coverMime = hasArticleSortCover ? article.article_sort_cover_mime : article.cover_mime
+          - const articleSortVideoParameters = article.article_sort_video_parameters || {}
+          - const coverVideoParameters = article.cover_video_parameters || {}
+          - const autoplay = hasArticleSortCover ? articleSortVideoParameters.autoplay : (articleSortVideoParameters.autoplay ?? coverVideoParameters.autoplay)
+          - const loop = hasArticleSortCover ? articleSortVideoParameters.loop : (articleSortVideoParameters.loop ?? coverVideoParameters.loop)
+          - const poster = hasArticleSortCover ? articleSortVideoParameters.poster : (articleSortVideoParameters.poster ?? coverVideoParameters.poster)
+          if coverType === 'video' && isEager && poster
+            link(rel='preload' as='image' href=url_for(poster) fetchpriority='high')
           a.article-sort-item-img(href=url_for(article.path) title=title)
-            - const eagerCoversCount = theme.LCP_Optimization.enable ? (theme.LCP_Optimization.articles_sort_page ?? 0) : 0
-            - const isEager = index < eagerCoversCount
-            - const coverType = hasArticleSortCover ? article.article_sort_cover_type : article.cover_type
-            - const coverMime = hasArticleSortCover ? article.article_sort_cover_mime : article.cover_mime
-            - const articleSortVideoParameters = article.article_sort_video_parameters || {}
-            - const coverVideoParameters = article.cover_video_parameters || {}
-            - const autoplay = hasArticleSortCover ? articleSortVideoParameters.autoplay : (articleSortVideoParameters.autoplay ?? coverVideoParameters.autoplay)
-            - const loop = hasArticleSortCover ? articleSortVideoParameters.loop : (articleSortVideoParameters.loop ?? coverVideoParameters.loop)
-            - const poster = hasArticleSortCover ? articleSortVideoParameters.poster : (articleSortVideoParameters.poster ?? coverVideoParameters.poster)
             if coverType === 'video'
               video(autoplay=autoplay loop=loop muted playsinline poster=poster ? url_for(poster) : undefined)
                 source(src=url_for(cover) type=coverMime || undefined)

--- a/layout/includes/mixins/article-sort.pug
+++ b/layout/includes/mixins/article-sort.pug
@@ -1,20 +1,30 @@
 mixin articleSort(posts)
   .article-sort
     - let year
-    - posts.forEach(article => {
+    - posts.forEach((article, index) => {
       - const tempYear = date(article.date, 'YYYY')
-      - const noCoverClass = article.cover === false || !theme.cover.archives_enable ? 'no-article-cover' : ''
+      - const post_cover = article.article_sort_cover === false ? false : (article.article_sort_cover || article.cover)
+      - const noCoverClass = post_cover === false || !theme.cover.archives_enable ? 'no-article-cover' : ''
       - const title = article.title || _p('no_title')
       if tempYear !== year
         - year = tempYear
         .article-sort-item.year= year
       .article-sort-item(class=noCoverClass)
-        if article.cover && theme.cover.archives_enable
+        if post_cover && theme.cover.archives_enable
           a.article-sort-item-img(href=url_for(article.path) title=title)
-            if article.cover_type === 'img'
-              img(src=url_for(article.cover) alt=title onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'`)
+            - const eagerCoversCount = theme.LCP_Optimization.enable ? (theme.LCP_Optimization.articles_sort_page ?? 0) : 0
+            - const isEager = index < eagerCoversCount
+            - const post_cover_type = article.article_sort_cover_type || article.cover_type
+            - const post_cover_mime = article.article_sort_cover_mime || article.cover_mime
+            - const cover_video_parameters = article.cover_video_parameters || {}
+            - const post_video_cover = cover_video_parameters.post_video_cover
+            if post_cover_type === 'video'
+              video(autoplay=cover_video_parameters.autoplay loop=cover_video_parameters.loop muted playsinline preload=isEager ? 'metadata' : 'none' poster=post_video_cover ? url_for(post_video_cover) : undefined)
+                source(src=url_for(post_cover) type=post_cover_mime)
+            else if post_cover_type === 'img'
+              img(src=url_for(post_cover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title loading=isEager ? 'eager' : undefined fetchpriority=isEager ? 'high' : undefined decoding=isEager ? undefined : 'async')
             else
-              div(style=`background: ${article.cover}`)
+              div(style=`background: ${post_cover}`)
         .article-sort-item-info
           .article-sort-item-time
             i.far.fa-calendar-alt

--- a/layout/includes/mixins/article-sort.pug
+++ b/layout/includes/mixins/article-sort.pug
@@ -19,7 +19,7 @@ mixin articleSort(posts)
             - const cover_video_parameters = article.cover_video_parameters || {}
             - const post_video_cover = cover_video_parameters.post_video_cover
             if post_cover_type === 'video'
-              video(autoplay=cover_video_parameters.autoplay loop=cover_video_parameters.loop muted playsinline preload=isEager ? 'metadata' : 'none' poster=post_video_cover ? url_for(post_video_cover) : undefined)
+              video(autoplay=cover_video_parameters.autoplay loop=cover_video_parameters.loop muted playsinline poster=post_video_cover ? url_for(post_video_cover) : undefined)
                 source(src=url_for(post_cover) type=post_cover_mime)
             else if post_cover_type === 'img'
               img(src=url_for(post_cover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title loading=isEager ? 'eager' : undefined fetchpriority=isEager ? 'high' : undefined decoding=isEager ? undefined : 'async')

--- a/layout/includes/mixins/indexPostUI.pug
+++ b/layout/includes/mixins/indexPostUI.pug
@@ -12,14 +12,14 @@ mixin indexPostUI()
           - const noCover = article.cover === false || !theme.cover.index_enable ? 'no-cover' : ''
 
           if postCover && theme.cover.index_enable
-            .postCover(class=leftOrRight)
+            .post_cover(class=leftOrRight)
               a(href=url_for(link) title=title)
                 - const eagerCoversCount = theme.LCP_Optimization.enable ? (theme.LCP_Optimization.main_page ?? 3) : 0
                 - const isEager = index < eagerCoversCount
-                - const cover_video_parameters = article.cover_video_parameters || {}
-                - const post_video_cover = cover_video_parameters.post_video_cover
+                - const coverVideoParameters = article.cover_video_parameters || {}
+                - const postVideoCover = coverVideoParameters.post_video_cover
                 if article.cover_type === 'video'
-                  video.post-bg(autoplay=cover_video_parameters.autoplay loop=cover_video_parameters.loop muted playsinline poster=post_video_cover ? url_for(post_video_cover) : undefined)
+                  video.post-bg(autoplay=coverVideoParameters.autoplay loop=coverVideoParameters.loop muted playsinline poster=postVideoCover ? url_for(postVideoCover) : undefined)
                     source(src=url_for(postCover) type=article.cover_mime)
                 else if article.cover_type === 'img'
                   img.post-bg(src=url_for(postCover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title loading=isEager ? 'eager' : undefined fetchpriority=isEager ? 'high' : undefined decoding=isEager ? undefined : 'async')

--- a/layout/includes/mixins/indexPostUI.pug
+++ b/layout/includes/mixins/indexPostUI.pug
@@ -17,7 +17,7 @@ mixin indexPostUI()
                 - const eagerCoversCount = theme.LCP_Optimization.enable ? (theme.LCP_Optimization.main_page ?? 3) : 0
                 - const isEager = index < eagerCoversCount
                 - const coverVideoParameters = article.cover_video_parameters || {}
-                - const postVideoCover = coverVideoParameters.cover_video_poster
+                - const postVideoCover = coverVideoParameters.poster
                 if article.cover_type === 'video'
                   if isEager && postVideoCover
                     link(rel='preload' as='image' href=url_for(postVideoCover) fetchpriority='high')

--- a/layout/includes/mixins/indexPostUI.pug
+++ b/layout/includes/mixins/indexPostUI.pug
@@ -17,10 +17,12 @@ mixin indexPostUI()
                 - const eagerCoversCount = theme.LCP_Optimization.enable ? (theme.LCP_Optimization.main_page ?? 3) : 0
                 - const isEager = index < eagerCoversCount
                 - const coverVideoParameters = article.cover_video_parameters || {}
-                - const postVideoCover = coverVideoParameters.post_video_cover
+                - const postVideoCover = coverVideoParameters.cover_video_poster
                 if article.cover_type === 'video'
+                  if isEager && postVideoCover
+                    link(rel='preload' as='image' href=url_for(postVideoCover) fetchpriority='high')
                   video.post-bg(autoplay=coverVideoParameters.autoplay loop=coverVideoParameters.loop muted playsinline poster=postVideoCover ? url_for(postVideoCover) : undefined)
-                    source(src=url_for(postCover) type=article.cover_mime)
+                    source(src=url_for(postCover) type=article.cover_mime || undefined)
                 else if article.cover_type === 'img'
                   img.post-bg(src=url_for(postCover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title loading=isEager ? 'eager' : undefined fetchpriority=isEager ? 'high' : undefined decoding=isEager ? undefined : 'async')
                 else

--- a/layout/includes/mixins/indexPostUI.pug
+++ b/layout/includes/mixins/indexPostUI.pug
@@ -12,10 +12,17 @@ mixin indexPostUI()
           - const noCover = article.cover === false || !theme.cover.index_enable ? 'no-cover' : ''
 
           if postCover && theme.cover.index_enable
-            .post_cover(class=leftOrRight)
+            .postCover(class=leftOrRight)
               a(href=url_for(link) title=title)
-                if article.cover_type === 'img'
-                  img.post-bg(src=url_for(postCover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title)
+                - const eagerCoversCount = theme.LCP_Optimization.enable ? (theme.LCP_Optimization.main_page ?? 3) : 0
+                - const isEager = index < eagerCoversCount
+                - const cover_video_parameters = article.cover_video_parameters || {}
+                - const post_video_cover = cover_video_parameters.post_video_cover
+                if article.cover_type === 'video'
+                  video.post-bg(autoplay=cover_video_parameters.autoplay loop=cover_video_parameters.loop muted playsinline preload=isEager ? 'metadata' : 'none' poster=post_video_cover ? url_for(post_video_cover) : undefined)
+                    source(src=url_for(postCover) type=article.cover_mime)
+                else if article.cover_type === 'img'
+                  img.post-bg(src=url_for(postCover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title loading=isEager ? 'eager' : undefined fetchpriority=isEager ? 'high' : undefined decoding=isEager ? undefined : 'async')
                 else
                   div.post-bg(style=`background: ${postCover}`)
           .recent-post-info(class=noCover)

--- a/layout/includes/mixins/indexPostUI.pug
+++ b/layout/includes/mixins/indexPostUI.pug
@@ -19,7 +19,7 @@ mixin indexPostUI()
                 - const cover_video_parameters = article.cover_video_parameters || {}
                 - const post_video_cover = cover_video_parameters.post_video_cover
                 if article.cover_type === 'video'
-                  video.post-bg(autoplay=cover_video_parameters.autoplay loop=cover_video_parameters.loop muted playsinline preload=isEager ? 'metadata' : 'none' poster=post_video_cover ? url_for(post_video_cover) : undefined)
+                  video.post-bg(autoplay=cover_video_parameters.autoplay loop=cover_video_parameters.loop muted playsinline poster=post_video_cover ? url_for(post_video_cover) : undefined)
                     source(src=url_for(postCover) type=article.cover_mime)
                 else if article.cover_type === 'img'
                   img.post-bg(src=url_for(postCover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title loading=isEager ? 'eager' : undefined fetchpriority=isEager ? 'high' : undefined decoding=isEager ? undefined : 'async')

--- a/layout/includes/mixins/indexPostUI.pug
+++ b/layout/includes/mixins/indexPostUI.pug
@@ -13,15 +13,15 @@ mixin indexPostUI()
 
           if postCover && theme.cover.index_enable
             .post_cover(class=leftOrRight)
+              - const eagerCoversCount = theme.LCP_Optimization.enable ? (theme.LCP_Optimization.main_page ?? 3) : 0
+              - const isEager = index < eagerCoversCount
+              - const coverVideoParameters = article.cover_video_parameters || {}
+              - const poster = coverVideoParameters.poster
+              if article.cover_type === 'video' && isEager && poster
+                link(rel='preload' as='image' href=url_for(poster) fetchpriority='high')
               a(href=url_for(link) title=title)
-                - const eagerCoversCount = theme.LCP_Optimization.enable ? (theme.LCP_Optimization.main_page ?? 3) : 0
-                - const isEager = index < eagerCoversCount
-                - const coverVideoParameters = article.cover_video_parameters || {}
-                - const postVideoCover = coverVideoParameters.poster
                 if article.cover_type === 'video'
-                  if isEager && postVideoCover
-                    link(rel='preload' as='image' href=url_for(postVideoCover) fetchpriority='high')
-                  video.post-bg(autoplay=coverVideoParameters.autoplay loop=coverVideoParameters.loop muted playsinline poster=postVideoCover ? url_for(postVideoCover) : undefined)
+                  video.post-bg(autoplay=coverVideoParameters.autoplay loop=coverVideoParameters.loop muted playsinline poster=poster ? url_for(poster) : undefined)
                     source(src=url_for(postCover) type=article.cover_mime || undefined)
                 else if article.cover_type === 'img'
                   img.post-bg(src=url_for(postCover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title loading=isEager ? 'eager' : undefined fetchpriority=isEager ? 'high' : undefined decoding=isEager ? undefined : 'async')

--- a/layout/includes/pagination.pug
+++ b/layout/includes/pagination.pug
@@ -18,21 +18,23 @@ if page.total !== 1
           - className = getPostDesc ? className : className + ' no-desc'
 
           a.pagination-related(class=className href=url_for(direction.path) title=direction.title)
-            - const cover = direction.pagination_cover || direction.cover
-            - const coverType = direction.pagination_cover_type || direction.cover_type
-            - const coverMime = direction.pagination_cover_mime || direction.cover_mime
-            - const pvp = direction.pagination_video_parameters || {}
-            - const cvp = direction.cover_video_parameters || {}
-            - const autoplay = pvp.autoplay ?? cvp.autoplay
-            - const loop = pvp.loop ?? cvp.loop
-            - const poster = pvp.pagination_video_poster || cvp.post_video_cover
+            - const hasPaginationCover = direction.pagination_cover !== undefined
+            - const cover = hasPaginationCover ? direction.pagination_cover : direction.cover
+            - const coverType = hasPaginationCover ? direction.pagination_cover_type : direction.cover_type
+            - const coverMime = hasPaginationCover ? direction.pagination_cover_mime : direction.cover_mime
+            - const paginationVideoParameters = direction.pagination_video_parameters || {}
+            - const coverVideoParameters = direction.cover_video_parameters || {}
+            - const autoplay = hasPaginationCover ? paginationVideoParameters.autoplay : (paginationVideoParameters.autoplay ?? coverVideoParameters.autoplay)
+            - const loop = hasPaginationCover ? paginationVideoParameters.loop : (paginationVideoParameters.loop ?? coverVideoParameters.loop)
+            - const poster = hasPaginationCover ? paginationVideoParameters.pagination_video_poster : (paginationVideoParameters.pagination_video_poster ?? coverVideoParameters.cover_video_poster)
+
             if coverType === 'video'
               video.cover(autoplay=autoplay loop=loop muted playsinline poster=poster ? url_for(poster) : undefined)
-                source(src=url_for(cover) type=coverMime)
+                source(src=url_for(cover) type=coverMime || undefined)
             else if coverType === 'img'
-              img.cover(src=url_for(cover) onerror=`onerror=null;src='${url_for(theme.error_img.post_page)}'` alt=`cover of ${key === 'prev' ? 'previous' : 'next'} post`)
+              img.cover(src=url_for(cover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=`cover of ${key === 'prev' ? 'previous' : 'next'} post`)
             else
-              .cover(style=`background: ${direction.cover || 'var(--default-bg-color)'}`)
+              .cover(style=`background: ${cover || 'var(--default-bg-color)'}`)
             .info(class=key === 'prev' ? '' : 'text-right')
               .info-1
                 .info-item-1=_p(`pagination.${key}`)

--- a/layout/includes/pagination.pug
+++ b/layout/includes/pagination.pug
@@ -18,11 +18,21 @@ if page.total !== 1
           - className = getPostDesc ? className : className + ' no-desc'
 
           a.pagination-related(class=className href=url_for(direction.path) title=direction.title)
-            if direction.cover_type === 'img'
-              img.cover(src=url_for(direction.pagination_cover || direction.cover) onerror=`onerror=null;src='${url_for(theme.error_img.post_page)}'` alt=`cover of ${key === 'prev' ? 'previous' : 'next'} post`)
+            - const cover = direction.pagination_cover || direction.cover
+            - const coverType = direction.pagination_cover_type || direction.cover_type
+            - const coverMime = direction.pagination_cover_mime || direction.cover_mime
+            - const pvp = direction.pagination_video_parameters || {}
+            - const cvp = direction.cover_video_parameters || {}
+            - const autoplay = pvp.autoplay ?? cvp.autoplay
+            - const loop = pvp.loop ?? cvp.loop
+            - const poster = pvp.pagination_video_poster || cvp.post_video_cover
+            if coverType === 'video'
+              video.cover(autoplay=autoplay loop=loop muted playsinline preload='none' poster=poster ? url_for(poster) : undefined)
+                source(src=url_for(cover) type=coverMime)
+            else if coverType === 'img'
+              img.cover(src=url_for(cover) onerror=`onerror=null;src='${url_for(theme.error_img.post_page)}'` alt=`cover of ${key === 'prev' ? 'previous' : 'next'} post`)
             else
               .cover(style=`background: ${direction.cover || 'var(--default-bg-color)'}`)
-
             .info(class=key === 'prev' ? '' : 'text-right')
               .info-1
                 .info-item-1=_p(`pagination.${key}`)

--- a/layout/includes/pagination.pug
+++ b/layout/includes/pagination.pug
@@ -26,7 +26,7 @@ if page.total !== 1
             - const coverVideoParameters = direction.cover_video_parameters || {}
             - const autoplay = hasPaginationCover ? paginationVideoParameters.autoplay : (paginationVideoParameters.autoplay ?? coverVideoParameters.autoplay)
             - const loop = hasPaginationCover ? paginationVideoParameters.loop : (paginationVideoParameters.loop ?? coverVideoParameters.loop)
-            - const poster = hasPaginationCover ? paginationVideoParameters.pagination_video_poster : (paginationVideoParameters.pagination_video_poster ?? coverVideoParameters.cover_video_poster)
+            - const poster = hasPaginationCover ? paginationVideoParameters.poster : (paginationVideoParameters.poster ?? coverVideoParameters.poster)
 
             if coverType === 'video'
               video.cover(autoplay=autoplay loop=loop muted playsinline poster=poster ? url_for(poster) : undefined)

--- a/layout/includes/pagination.pug
+++ b/layout/includes/pagination.pug
@@ -27,7 +27,7 @@ if page.total !== 1
             - const loop = pvp.loop ?? cvp.loop
             - const poster = pvp.pagination_video_poster || cvp.post_video_cover
             if coverType === 'video'
-              video.cover(autoplay=autoplay loop=loop muted playsinline preload='none' poster=poster ? url_for(poster) : undefined)
+              video.cover(autoplay=autoplay loop=loop muted playsinline poster=poster ? url_for(poster) : undefined)
                 source(src=url_for(cover) type=coverMime)
             else if coverType === 'img'
               img.cover(src=url_for(cover) onerror=`onerror=null;src='${url_for(theme.error_img.post_page)}'` alt=`cover of ${key === 'prev' ? 'previous' : 'next'} post`)

--- a/layout/includes/widget/card_recent_post.pug
+++ b/layout/includes/widget/card_recent_post.pug
@@ -9,15 +9,17 @@ if theme.aside.card_recent_post.enable
       - site.posts.sort(sort, -1).limit(postLimit).each(function(article){
         - let link = article.link || article.path
         - let title = article.title || _p('no_title')
-        - let no_cover = article.cover === false || !theme.cover.aside_enable ? 'no-cover' : ''
-        - let post_cover = article.cover
+        - let has_recent_post_cover = article.recent_post_cover !== undefined
+        - let effective_cover = has_recent_post_cover ? article.recent_post_cover : article.cover
+        - let effective_cover_type = has_recent_post_cover ? article.recent_post_cover_type : article.cover_type
+        - let no_cover = effective_cover === false || !theme.cover.aside_enable ? 'no-cover' : ''
         .aside-list-item(class=no_cover)
-          if post_cover && theme.cover.aside_enable
+          if effective_cover && theme.cover.aside_enable
             a.thumbnail(href=url_for(link) title=title)
-              if article.cover_type === 'img'
-                img(src=url_for(post_cover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title)
+              if effective_cover_type === 'img'
+                img(src=url_for(effective_cover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title)
               else
-                div(style=`background: ${post_cover}`)
+                div(style=`background: ${effective_cover}`)
           .content
             a.title(href=url_for(link) title=title)= title
             if theme.aside.card_recent_post.sort === 'updated'

--- a/layout/includes/widget/card_recent_post.pug
+++ b/layout/includes/widget/card_recent_post.pug
@@ -17,7 +17,7 @@ if theme.aside.card_recent_post.enable
         - let coverVideoParameters = article.cover_video_parameters || {}
         - let autoplay = hasRecentPostCover ? recentPostVideoParameters.autoplay : (recentPostVideoParameters.autoplay ?? coverVideoParameters.autoplay)
         - let loop = hasRecentPostCover ? recentPostVideoParameters.loop : (recentPostVideoParameters.loop ?? coverVideoParameters.loop)
-        - let poster = hasRecentPostCover ? recentPostVideoParameters.recent_post_video_poster : (recentPostVideoParameters.recent_post_video_poster ?? coverVideoParameters.cover_video_poster)
+        - let poster = hasRecentPostCover ? recentPostVideoParameters.poster : (recentPostVideoParameters.poster ?? coverVideoParameters.poster)
         - let noCoverClass = cover === false || !theme.cover.aside_enable ? 'no-cover' : ''
         .aside-list-item(class=noCoverClass)
           if cover && theme.cover.aside_enable

--- a/layout/includes/widget/card_recent_post.pug
+++ b/layout/includes/widget/card_recent_post.pug
@@ -10,16 +10,25 @@ if theme.aside.card_recent_post.enable
         - let link = article.link || article.path
         - let title = article.title || _p('no_title')
         - let hasRecentPostCover = article.recent_post_cover !== undefined
-        - let effectiveCover = hasRecentPostCover ? article.recent_post_cover : article.cover
-        - let effectiveCoverType = hasRecentPostCover ? article.recent_post_cover_type : article.cover_type
-        - let noCoverClass = effectiveCover === false || !theme.cover.aside_enable ? 'no-cover' : ''
+        - let cover = hasRecentPostCover ? article.recent_post_cover : article.cover
+        - let coverType = hasRecentPostCover ? article.recent_post_cover_type : article.cover_type
+        - let coverMime = hasRecentPostCover ? article.recent_post_cover_mime : article.cover_mime
+        - let recentPostVideoParameters = article.recent_post_video_parameters || {}
+        - let coverVideoParameters = article.cover_video_parameters || {}
+        - let autoplay = hasRecentPostCover ? recentPostVideoParameters.autoplay : (recentPostVideoParameters.autoplay ?? coverVideoParameters.autoplay)
+        - let loop = hasRecentPostCover ? recentPostVideoParameters.loop : (recentPostVideoParameters.loop ?? coverVideoParameters.loop)
+        - let poster = hasRecentPostCover ? recentPostVideoParameters.recent_post_video_poster : (recentPostVideoParameters.recent_post_video_poster ?? coverVideoParameters.cover_video_poster)
+        - let noCoverClass = cover === false || !theme.cover.aside_enable ? 'no-cover' : ''
         .aside-list-item(class=noCoverClass)
-          if effectiveCover && theme.cover.aside_enable
+          if cover && theme.cover.aside_enable
             a.thumbnail(href=url_for(link) title=title)
-              if effectiveCoverType === 'img'
-                img(src=url_for(effectiveCover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title)
+              if coverType === 'video'
+                video(autoplay=autoplay loop=loop muted playsinline poster=poster ? url_for(poster) : undefined)
+                  source(src=url_for(cover) type=coverMime || undefined)
+              else if coverType === 'img'
+                img(src=url_for(cover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title)
               else
-                div(style=`background: ${effectiveCover}`)
+                div(style=`background: ${cover}`)
           .content
             a.title(href=url_for(link) title=title)= title
             if theme.aside.card_recent_post.sort === 'updated'

--- a/layout/includes/widget/card_recent_post.pug
+++ b/layout/includes/widget/card_recent_post.pug
@@ -9,17 +9,17 @@ if theme.aside.card_recent_post.enable
       - site.posts.sort(sort, -1).limit(postLimit).each(function(article){
         - let link = article.link || article.path
         - let title = article.title || _p('no_title')
-        - let has_recent_post_cover = article.recent_post_cover !== undefined
-        - let effective_cover = has_recent_post_cover ? article.recent_post_cover : article.cover
-        - let effective_cover_type = has_recent_post_cover ? article.recent_post_cover_type : article.cover_type
-        - let no_cover = effective_cover === false || !theme.cover.aside_enable ? 'no-cover' : ''
-        .aside-list-item(class=no_cover)
-          if effective_cover && theme.cover.aside_enable
+        - let hasRecentPostCover = article.recent_post_cover !== undefined
+        - let effectiveCover = hasRecentPostCover ? article.recent_post_cover : article.cover
+        - let effectiveCoverType = hasRecentPostCover ? article.recent_post_cover_type : article.cover_type
+        - let noCoverClass = effectiveCover === false || !theme.cover.aside_enable ? 'no-cover' : ''
+        .aside-list-item(class=noCoverClass)
+          if effectiveCover && theme.cover.aside_enable
             a.thumbnail(href=url_for(link) title=title)
-              if effective_cover_type === 'img'
-                img(src=url_for(effective_cover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title)
+              if effectiveCoverType === 'img'
+                img(src=url_for(effectiveCover) onerror=`this.onerror=null;this.src='${url_for(theme.error_img.post_page)}'` alt=title)
               else
-                div(style=`background: ${effective_cover}`)
+                div(style=`background: ${effectiveCover}`)
           .content
             a.title(href=url_for(link) title=title)= title
             if theme.aside.card_recent_post.sort === 'updated'

--- a/scripts/common/default_config.js
+++ b/scripts/common/default_config.js
@@ -563,6 +563,11 @@ module.exports = {
     bg_dark: '#1f1f1f'
   },
   instantpage: false,
+  LCP_Optimization: {
+    enable: false,
+    main_page: 3,
+    articles_sort_page: 8,
+  },
   lazyload: {
     enable: false,
     native: false,

--- a/scripts/filters/random_cover.js
+++ b/scripts/filters/random_cover.js
@@ -41,34 +41,31 @@ hexo.extend.generator.register('post', locals => {
 
   const coverGenerator = createCoverGenerator()
 
-  const normalizeVideoParams = (data, paramsKey, posterKey) => {
+  const normalizeVideoParams = (data, paramsKey) => {
     let params = data[paramsKey]
     if (!params || typeof params !== 'object') params = {}
-
-    let poster = params[posterKey]
+  
+    let poster = params.poster
     if (typeof poster === 'string') poster = poster.trim()
-
-    params[posterKey] = poster
-    if (params.autoplay !== undefined && params.autoplay !== null) {
-      params.autoplay = params.autoplay === true
-    }
-    if (params.loop !== undefined && params.loop !== null) {
-      params.loop = params.loop === true
-    }
-
+    if (poster === '') poster = undefined
+  
+    if (params.autoplay !== undefined && params.autoplay !== null) params.autoplay = params.autoplay === true
+    if (params.loop !== undefined && params.loop !== null) params.loop = params.loop === true
+  
     if (postAssetFolder && poster && poster.indexOf('/') === -1 && imgTestReg.test(poster)) {
-      params[posterKey] = `${data.path}${poster}`
+      poster = `${data.path}${poster}`
     }
-
+  
+    params.poster = poster
     data[paramsKey] = params
   }
 
   const handleVideo = data => {
-    normalizeVideoParams(data, 'cover_video_parameters', 'cover_video_poster')
-    normalizeVideoParams(data, 'pagination_video_parameters', 'pagination_video_poster')
-    normalizeVideoParams(data, 'article_sort_video_parameters', 'article_sort_video_poster')
-    normalizeVideoParams(data, 'recent_post_video_parameters', 'recent_post_video_poster')
-    normalizeVideoParams(data, 'related_post_video_parameters', 'related_post_video_poster')
+    normalizeVideoParams(data, 'cover_video_parameters')
+    normalizeVideoParams(data, 'pagination_video_parameters')
+    normalizeVideoParams(data, 'article_sort_video_parameters')
+    normalizeVideoParams(data, 'recent_post_video_parameters')
+    normalizeVideoParams(data, 'related_post_video_parameters')
     return data
   }
 

--- a/scripts/filters/random_cover.js
+++ b/scripts/filters/random_cover.js
@@ -79,13 +79,7 @@ hexo.extend.generator.register('post', locals => {
 
   const handleImg = data => {
     data = handleVideo(data)
-    let {
-      cover: coverVal,
-      top_img: topImg,
-      pagination_cover: paginationCover,
-      recent_post_cover: recentPostCover,
-      article_sort_cover: articleSortCover
-    } = data
+    let { cover: coverVal, top_img: topImg, pagination_cover: paginationCover, recent_post_cover: recentPostCover, article_sort_cover: articleSortCover } = data
 
     if (postAssetFolder) {
       if (topImg && topImg.indexOf('/') === -1 && imgTestReg.test(topImg)) {

--- a/scripts/filters/random_cover.js
+++ b/scripts/filters/random_cover.js
@@ -52,8 +52,8 @@ hexo.extend.generator.register('post', locals => {
     if (typeof postVideoCover === 'string') postVideoCover = postVideoCover.trim()
 
     coverVideoParameters.post_video_cover = postVideoCover
-    coverVideoParameters.autoplay = coverVideoParameters.autoplay ?? true
-    coverVideoParameters.loop = coverVideoParameters.loop ?? true
+    coverVideoParameters.autoplay = coverVideoParameters.autoplay ?? false
+    coverVideoParameters.loop = coverVideoParameters.loop ?? false
 
     if (postAssetFolder && postVideoCover && postVideoCover.indexOf('/') === -1 && imgTestReg.test(postVideoCover)) {
       coverVideoParameters.post_video_cover = `${data.path}${postVideoCover}`
@@ -64,8 +64,8 @@ hexo.extend.generator.register('post', locals => {
     if (typeof paginationVideoPoster === 'string') paginationVideoPoster = paginationVideoPoster.trim()
 
     paginationVideoParameters.pagination_video_poster = paginationVideoPoster
-    paginationVideoParameters.autoplay = paginationVideoParameters.autoplay ?? true
-    paginationVideoParameters.loop = paginationVideoParameters.loop ?? true
+    paginationVideoParameters.autoplay = paginationVideoParameters.autoplay ?? false
+    paginationVideoParameters.loop = paginationVideoParameters.loop ?? false
 
     if (postAssetFolder && paginationVideoPoster && paginationVideoPoster.indexOf('/') === -1 && imgTestReg.test(paginationVideoPoster)) {
       paginationVideoParameters.pagination_video_poster = `${data.path}${paginationVideoPoster}`

--- a/scripts/filters/random_cover.js
+++ b/scripts/filters/random_cover.js
@@ -6,6 +6,7 @@
 
 hexo.extend.generator.register('post', locals => {
   const imgTestReg = /\.(png|jpe?g|gif|svg|webp|avif)(\?.*)?$/i
+  const videoTestReg = /\.(mp4|webm)(\?.*)?$/i
   const { post_asset_folder: postAssetFolder } = hexo.config
   const { cover: { default_cover: defaultCover } } = hexo.theme.config
 
@@ -40,32 +41,100 @@ hexo.extend.generator.register('post', locals => {
 
   const coverGenerator = createCoverGenerator()
 
-  const handleImg = data => {
-    let { cover: coverVal, top_img: topImg, pagination_cover: paginationCover } = data
+  const handleVideo = data => {
+    let { cover_video_parameters: coverVideoParameters, pagination_video_parameters: paginationVideoParameters } = data
 
-    // Add path to top_img and cover if post_asset_folder is enabled
+    if (!coverVideoParameters || typeof coverVideoParameters !== 'object') coverVideoParameters = {}
+    if (!paginationVideoParameters || typeof paginationVideoParameters !== 'object') paginationVideoParameters = {}
+
+    let { post_video_cover: postVideoCover } = coverVideoParameters
+
+    if (typeof postVideoCover === 'string') postVideoCover = postVideoCover.trim()
+
+    coverVideoParameters.post_video_cover = postVideoCover
+    coverVideoParameters.autoplay = coverVideoParameters.autoplay ?? true
+    coverVideoParameters.loop = coverVideoParameters.loop ?? true
+
+    if (postAssetFolder && postVideoCover && postVideoCover.indexOf('/') === -1 && imgTestReg.test(postVideoCover)) {
+      coverVideoParameters.post_video_cover = `${data.path}${postVideoCover}`
+    }
+
+    let { pagination_video_poster: paginationVideoPoster } = paginationVideoParameters
+
+    if (typeof paginationVideoPoster === 'string') paginationVideoPoster = paginationVideoPoster.trim()
+
+    paginationVideoParameters.pagination_video_poster = paginationVideoPoster
+    paginationVideoParameters.autoplay = paginationVideoParameters.autoplay ?? true
+    paginationVideoParameters.loop = paginationVideoParameters.loop ?? true
+
+    if (postAssetFolder && paginationVideoPoster && paginationVideoPoster.indexOf('/') === -1 && imgTestReg.test(paginationVideoPoster)) {
+      paginationVideoParameters.pagination_video_poster = `${data.path}${paginationVideoPoster}`
+    }
+
+    data.cover_video_parameters = coverVideoParameters
+    data.pagination_video_parameters = paginationVideoParameters
+
+    return data
+  }
+
+  const handleImg = data => {
+    data = handleVideo(data)
+    let {
+      cover: coverVal,
+      top_img: topImg,
+      pagination_cover: paginationCover,
+      recent_post_cover: recentPostCover,
+      article_sort_cover: articleSortCover
+    } = data
+
     if (postAssetFolder) {
       if (topImg && topImg.indexOf('/') === -1 && imgTestReg.test(topImg)) {
         data.top_img = `${data.path}${topImg}`
       }
-      if (coverVal && coverVal.indexOf('/') === -1 && imgTestReg.test(coverVal)) {
+      if (coverVal && coverVal.indexOf('/') === -1 && (imgTestReg.test(coverVal) || videoTestReg.test(coverVal))) {
         data.cover = `${data.path}${coverVal}`
       }
-      if (paginationCover && paginationCover.indexOf('/') === -1 && imgTestReg.test(paginationCover)) {
+      if (paginationCover && paginationCover.indexOf('/') === -1 && (imgTestReg.test(paginationCover) || videoTestReg.test(paginationCover))) {
         data.pagination_cover = `${data.path}${paginationCover}`
       }
+      if (recentPostCover && recentPostCover.indexOf('/') === -1 && imgTestReg.test(recentPostCover)) {
+        data.recent_post_cover = `${data.path}${recentPostCover}`
+      }
+      if (articleSortCover && articleSortCover.indexOf('/') === -1 && (imgTestReg.test(articleSortCover) || videoTestReg.test(articleSortCover))) {
+        data.article_sort_cover = `${data.path}${articleSortCover}`
+      }
+    }
+
+    if (paginationCover && videoTestReg.test(paginationCover)) {
+      data.pagination_cover_type = 'video'
+      data.pagination_cover_mime = /\.webm(\?.*)?$/i.test(paginationCover) ? 'video/webm' : 'video/mp4'
+    } else if (paginationCover && (paginationCover.indexOf('//') !== -1 || imgTestReg.test(paginationCover))) {
+      data.pagination_cover_type = 'img'
+    }
+
+    if (articleSortCover && videoTestReg.test(articleSortCover)) {
+      data.article_sort_cover_type = 'video'
+      data.article_sort_cover_mime = /\.webm(\?.*)?$/i.test(articleSortCover) ? 'video/webm' : 'video/mp4'
+    } else if (articleSortCover && (articleSortCover.indexOf('//') !== -1 || imgTestReg.test(articleSortCover))) {
+      data.article_sort_cover_type = 'img'
+    }
+
+    if (recentPostCover && (recentPostCover.indexOf('//') !== -1 || imgTestReg.test(recentPostCover))) {
+      data.recent_post_cover_type = 'img'
     }
 
     if (coverVal === false) return data
 
-    // If cover is not set, use random cover
     if (!coverVal) {
       const randomCover = coverGenerator.next().value
       data.cover = randomCover
       coverVal = randomCover
     }
 
-    if (coverVal && (coverVal.indexOf('//') !== -1 || imgTestReg.test(coverVal))) {
+    if (coverVal && videoTestReg.test(coverVal)) {
+      data.cover_type = 'video'
+      data.cover_mime = /\.webm(\?.*)?$/i.test(coverVal) ? 'video/webm' : 'video/mp4'
+    } else if (coverVal && (coverVal.indexOf('//') !== -1 || imgTestReg.test(coverVal))) {
       data.cover_type = 'img'
     }
 

--- a/scripts/helpers/related_post.js
+++ b/scripts/helpers/related_post.js
@@ -80,14 +80,14 @@ hexo.extend.helper.register('related_posts', function (currentPost) {
     const relatedVideoParameters = relatedPostVideoParameters || {}
     const autoplay = hasRelatedPostCover ? relatedVideoParameters.autoplay : (relatedVideoParameters.autoplay ?? coverVideoParameters.autoplay)
     const loop = hasRelatedPostCover ? relatedVideoParameters.loop : (relatedVideoParameters.loop ?? coverVideoParameters.loop)
-    const poster = hasRelatedPostCover ? relatedVideoParameters.related_post_video_poster : (relatedVideoParameters.related_post_video_poster ?? coverVideoParameters.cover_video_poster)
+    const poster = hasRelatedPostCover ? relatedVideoParameters.poster : (relatedVideoParameters.poster ?? coverVideoParameters.poster)
 
     cover = cover || 'var(--default-bg-color)'
     title = escape_html(title)
     const className = postDesc ? 'pagination-related' : 'pagination-related no-desc'
     result += `<a class="${className}" href="${url_for(path)}" title="${title}">`
     if (coverType === 'img') {
-      result += `<img class="cover" src="${url_for(cover)}" alt="cover">`
+      result += `<img class="cover" src="${url_for(cover)}" onerror="this.onerror=null;this.src='${url_for(config.error_img.post_page)}'" alt="cover">`
     } else if (coverType === 'video') {
       result += `<video class="cover"${autoplay === true ? ' autoplay' : ''}${loop === true ? ' loop' : ''} muted playsinline${poster ? ` poster="${url_for(poster)}"` : ''}>`
       result += `<source src="${url_for(cover)}"${coverMime ? ` type="${coverMime}"` : ''}>`

--- a/scripts/helpers/related_post.js
+++ b/scripts/helpers/related_post.js
@@ -29,6 +29,8 @@ hexo.extend.helper.register('related_posts', function (currentPost) {
           path: post.path,
           cover: post.cover,
           cover_type: post.cover_type,
+          cover_mime: post.cover_mime,
+          cover_video_parameters: post.cover_video_parameters,
           weight: 1,
           updated: post.updated,
           created: post.date,
@@ -62,7 +64,7 @@ hexo.extend.helper.register('related_posts', function (currentPost) {
   result += '<div class="relatedPosts-list">'
 
   for (let i = 0; i < Math.min(relatedPostsList.length, limitNum); i++) {
-    let { cover, title, path, cover_type, created, updated, postDesc } = relatedPostsList[i]
+    let { cover, title, path, cover_type, cover_mime, cover_video_parameters, created, updated, postDesc } = relatedPostsList[i]
     const { escape_html, url_for, date } = this
     cover = cover || 'var(--default-bg-color)'
     title = escape_html(title)
@@ -70,6 +72,12 @@ hexo.extend.helper.register('related_posts', function (currentPost) {
     result += `<a class="${className}" href="${url_for(path)}" title="${title}">`
     if (cover_type === 'img') {
       result += `<img class="cover" src="${url_for(cover)}" alt="cover">`
+    } else if (cover_type === 'video') {
+      const cvp = cover_video_parameters || {}
+      const poster = cvp.post_video_cover
+      result += `<video class="cover"${cvp.autoplay ? ' autoplay' : ''}${cvp.loop ? ' loop' : ''} muted playsinline preload="none"${poster ? ` poster="${url_for(poster)}"` : ''}>`
+      result += `<source src="${url_for(cover)}"${cover_mime ? ` type="${cover_mime}"` : ''}>`
+      result += `</video>`
     } else {
       result += `<div class="cover" style="background: ${cover}"></div>`
     }

--- a/scripts/helpers/related_post.js
+++ b/scripts/helpers/related_post.js
@@ -75,7 +75,7 @@ hexo.extend.helper.register('related_posts', function (currentPost) {
     } else if (cover_type === 'video') {
       const cvp = cover_video_parameters || {}
       const poster = cvp.post_video_cover
-      result += `<video class="cover"${cvp.autoplay ? ' autoplay' : ''}${cvp.loop ? ' loop' : ''} muted playsinline preload="none"${poster ? ` poster="${url_for(poster)}"` : ''}>`
+      result += `<video class="cover"${cvp.autoplay ? ' autoplay' : ''}${cvp.loop ? ' loop' : ''} muted playsinline${poster ? ` poster="${url_for(poster)}"` : ''}>`
       result += `<source src="${url_for(cover)}"${cover_mime ? ` type="${cover_mime}"` : ''}>`
       result += `</video>`
     } else {

--- a/scripts/helpers/related_post.js
+++ b/scripts/helpers/related_post.js
@@ -31,6 +31,10 @@ hexo.extend.helper.register('related_posts', function (currentPost) {
           cover_type: post.cover_type,
           cover_mime: post.cover_mime,
           cover_video_parameters: post.cover_video_parameters,
+          related_post_cover: post.related_post_cover,
+          related_post_cover_type: post.related_post_cover_type,
+          related_post_cover_mime: post.related_post_cover_mime,
+          related_post_video_parameters: post.related_post_video_parameters,
           weight: 1,
           updated: post.updated,
           created: post.date,
@@ -64,19 +68,29 @@ hexo.extend.helper.register('related_posts', function (currentPost) {
   result += '<div class="relatedPosts-list">'
 
   for (let i = 0; i < Math.min(relatedPostsList.length, limitNum); i++) {
-    let { cover, title, path, cover_type, cover_mime, cover_video_parameters, created, updated, postDesc } = relatedPostsList[i]
+    let { title, path, cover: baseCover, cover_type: baseCoverType, cover_mime: baseCoverMime, cover_video_parameters: coverVideoParameters, related_post_cover: relatedPostCover, related_post_cover_type: relatedPostCoverType, related_post_cover_mime: relatedPostCoverMime, related_post_video_parameters: relatedPostVideoParameters, created, updated, postDesc } = relatedPostsList[i]
     const { escape_html, url_for, date } = this
+
+    const hasRelatedPostCover = relatedPostCover !== undefined
+    let cover = hasRelatedPostCover ? relatedPostCover : baseCover
+    const coverType = hasRelatedPostCover ? relatedPostCoverType : baseCoverType
+    const coverMime = hasRelatedPostCover ? relatedPostCoverMime : baseCoverMime
+
+    coverVideoParameters = coverVideoParameters || {}
+    const relatedVideoParameters = relatedPostVideoParameters || {}
+    const autoplay = hasRelatedPostCover ? relatedVideoParameters.autoplay : (relatedVideoParameters.autoplay ?? coverVideoParameters.autoplay)
+    const loop = hasRelatedPostCover ? relatedVideoParameters.loop : (relatedVideoParameters.loop ?? coverVideoParameters.loop)
+    const poster = hasRelatedPostCover ? relatedVideoParameters.related_post_video_poster : (relatedVideoParameters.related_post_video_poster ?? coverVideoParameters.cover_video_poster)
+
     cover = cover || 'var(--default-bg-color)'
     title = escape_html(title)
     const className = postDesc ? 'pagination-related' : 'pagination-related no-desc'
     result += `<a class="${className}" href="${url_for(path)}" title="${title}">`
-    if (cover_type === 'img') {
+    if (coverType === 'img') {
       result += `<img class="cover" src="${url_for(cover)}" alt="cover">`
-    } else if (cover_type === 'video') {
-      const cvp = cover_video_parameters || {}
-      const poster = cvp.post_video_cover
-      result += `<video class="cover"${cvp.autoplay ? ' autoplay' : ''}${cvp.loop ? ' loop' : ''} muted playsinline${poster ? ` poster="${url_for(poster)}"` : ''}>`
-      result += `<source src="${url_for(cover)}"${cover_mime ? ` type="${cover_mime}"` : ''}>`
+    } else if (coverType === 'video') {
+      result += `<video class="cover"${autoplay === true ? ' autoplay' : ''}${loop === true ? ' loop' : ''} muted playsinline${poster ? ` poster="${url_for(poster)}"` : ''}>`
+      result += `<source src="${url_for(cover)}"${coverMime ? ` type="${coverMime}"` : ''}>`
       result += `</video>`
     } else {
       result += `<div class="cover" style="background: ${cover}"></div>`


### PR DESCRIPTION
## PR Context

Hi! I know this PR doesn’t align with the simplicity-first direction Jerry wants to follow as stated on https://github.com/jerryc127/hexo-theme-butterfly/pull/1774#issuecomment-3731942457. I implemented it for my own blog and I’m sharing it in case it is useful to others. Jerry, feel free to close the PR.

This PR  is already implemented on my personal blog https://void4m0n.com/

## Motivation

I wanted to add more dynamism to my blog. Since Butterfly didn’t support video covers, I initially used GIFs, but they are not optimal for performance or user experience. Using video instead of GIF is generally recommended, so I implemented video cover support across the theme’s cover slots.

Separately, I noticed that with Lazy mode enabled, some above-the-fold covers (part of the LCP) were still treated as lazy-loaded, negatively impacting Web Core Vitals. This PR also adds a small configuration option to prioritize the first N covers.

## Video cover support and fallbacks

### What changed
This PR extends the existing cover system to support `video` in addition to the current behavior (`img` / CSS background string), across:

- `cover` (main page)
- `pagination_cover` (post page)
- `related_post` (post page)
- `recent_post` (main page)
- `article_sort` (articles page)

### Supported video formats (auto-detected)
Video support is auto-detected from the cover value (no manual type selection):

- `.mp4` and `.webm`

When detected as video, the theme renders `<video><source></video>` and sets `cover_mime` automatically:
- `.webm` -> `video/webm`
- otherwise -> `video/mp4`

### Configurable video parameters (YAML examples)
Video rendering always includes:
- `muted`, `playsinline`

`autoplay`, `loop` & `poster` are User-configurable parameters provided via `*_video_parameters` objects. Example (main cover):

~~~yaml
cover: intro.mp4
cover_video_parameters:
  autoplay: true
  loop: true
  poster: intro-poster.web
~~~

Section-specific examples:

~~~yaml
pagination_cover: pagination.mp4
pagination_video_parameters:
  autoplay: true
  loop: false
  poster: pagination-poster.webp

recent_post_cover: recent.mp4
recent_post_video_parameters:
  autoplay: false
  loop: true
  poster: recent-poster.webp

article_sort_cover: sort.mp4
article_sort_video_parameters:
  autoplay: true
  loop: true
  poster: sort-poster.webp

related_post_cover: related.mp4
related_post_video_parameters:
  autoplay: false
  loop: true
  poster: related-poster.webp
~~~

### Parameter workflow (inheritance / overrides)
Per-section overrides are supported via `*_video_parameters`, even if a section-specific cover is not defined.

- If a parameter is defined in `*_video_parameters`, it is used
- Otherwise, it inherits from `cover_video_parameters` (per-parameter inheritance)

### No-cover behavior (`false`) 
- Can be disabled with `false`: `cover`, `recent_post`, `article_sort`
- Cannot be disabled with `false`: `pagination`, `related_post`

### Section cover fallback (when a section cover is missing)
If the section cover is not provided, the renderer falls back to the post’s main `cover` value:

- If `pagination_cover` is `undefined`, it falls back to `cover`
- If `related_post_cover` is `undefined`, it falls back to `cover`
- The same fallback pattern applies to other section covers (`recent_post_cover`, `article_sort_cover`) when they are not explicitly defined

This preserves the existing theme behavior: section-specific covers are optional overrides, and when they are not set the main `cover` is used as before.

## LCP_Optimization

With Lazy mode enabled, covers that end up being part of the LCP could still be treated as lazy-loaded, negatively impacting Web Core Vitals. This PR adds an option under `LCP_Optimization` to prioritize the first N covers (above-the-fold) so they are not affected by lazy-loading behavior.

### How it works
- A configurable number of covers on the index page & Article page are treated as “eager”.
```yaml
LCP_Optimization:
  enable: true
  main_page: 3 # default 3
  articles_sort_page: 8 # default 8
```
- For those covers:
  - **Images** are rendered with `loading="eager"` and `fetchpriority="high"` (and `decoding="async"` is avoided for eager items).
  - **Video covers** preload the poster using:
    - `<link rel="preload" as="image" href="...poster..." fetchpriority="high">`

### Note about preload placement
Ideally, the preload `<link>` should live in the document `<head>` so the browser can discover it as early as possible. In this implementation it is kept close to the cover markup to preserve simplicity and avoid introducing global head-injection logic, while still providing the intended effect: Web Core Vitals/Lighthouse no longer report the missing-preload warning for the LCP resource, which may translate into improved scoring while keeping the implementation straightforward.

## Additional fix (unrelated to video covers)

- Added an `onerror` fallback to the related posts `<img>` cover:
  - `onerror="this.onerror=null;this.src='...'"`

## TODO

If this PR is of interest, it may be worth adding a fallback for cases where a section-specific cover is configured but the referenced file does not exist. It is not fully clear to me whether the best target should be the  `404.jpg` image, or falling back to the base `cover`.

My preference would be to fall back to the `404.jpg`, since the user explicitly configured a section-specific cover and the requested asset is missing. That said, falling back to the base `cover` would also be a reasonable choice, depending on the desired UX.

## Extra Comments

Sorry for the many commits. I wanted to keep this PR as close as possible to the style used in the theme, and since I’ve been working on it in short sessions, I occasionally lost track of what I was changing and ended up committing more often than intended. Thanks, Jerry, for developing and maintaining this beautiful theme.
