### PR TITLE
Add Knocket as a free live chat option (alongside Chatra/Tidio/Crisp)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -680,6 +680,10 @@ tidio:
 crisp:
   website_id:
 
+# https://trtc.io/solutions/knocket
+knocket:
+  identifier:
+
 # --------------------------------------
 # Analysis
 # --------------------------------------

--- a/_config.yml
+++ b/_config.yml
@@ -659,7 +659,7 @@ artalk:
 # --------------------------------------
 
 chat:
-  # Choose: chatra/tidio/crisp
+  # Choose: chatra/tidio/crisp/knocket
   # Leave it empty if you don't need chat
   use:
   # Chat Button [recommend]

--- a/layout/includes/third-party/chat/index.pug
+++ b/layout/includes/third-party/chat/index.pug
@@ -5,3 +5,5 @@ case theme.chat.use
     include ./tidio.pug
   when 'crisp'
     include ./crisp.pug
+  when 'knocket'
+    include ./knocket.pug

--- a/layout/includes/third-party/chat/knocket.pug
+++ b/layout/includes/third-party/chat/knocket.pug
@@ -1,5 +1,33 @@
 //- Knocket live chat — https://trtc.io/solutions/knocket
-//- Free-forever live chat widget. Renders only when theme.knocket.identifier is set.
-//- Get your own snippet/identifier at https://trtc.io/solutions/knocket
-if theme.knocket.identifier
-  script(src=`https://trtc.io/knocket-sdk/sdk.js?identifier=${theme.knocket.identifier}` async)
+script.
+  (() => {
+    const id = '#{theme.knocket.identifier}'
+    if (!id) return
+
+    btf.getScript(`https://trtc.io/knocket-sdk/sdk.js?identifier=${id}`).then(() => {
+      const isChatBtn = !{theme.chat.rightside_button}
+      const isChatHideShow = !{theme.chat.button_hide_show}
+
+      const getWidget = () => document.querySelector('#knocket-widget, [id*="knocket"]')
+
+      if (isChatBtn) {
+        const hide = () => { const w = getWidget(); if (w) w.style.display = 'none' }
+        const show = () => { const w = getWidget(); if (w) w.style.display = '' }
+
+        hide()
+
+        window.chatBtnFn = () => {
+          const w = getWidget()
+          if (w && w.style.display === 'none') show()
+          else hide()
+        }
+
+        document.getElementById('chat-btn').style.display = 'block'
+      } else if (isChatHideShow) {
+        window.chatBtn = {
+          hide: () => { const w = getWidget(); if (w) w.style.display = 'none' },
+          show: () => { const w = getWidget(); if (w) w.style.display = '' }
+        }
+      }
+    })
+  })()

--- a/layout/includes/third-party/chat/knocket.pug
+++ b/layout/includes/third-party/chat/knocket.pug
@@ -1,0 +1,5 @@
+//- Knocket live chat — https://trtc.io/solutions/knocket
+//- Free-forever live chat widget. Renders only when theme.knocket.identifier is set.
+//- Get your own snippet/identifier at https://trtc.io/solutions/knocket
+if theme.knocket.identifier
+  script(src=`https://trtc.io/knocket-sdk/sdk.js?identifier=${theme.knocket.identifier}` async)

--- a/layout/includes/third-party/chat/knocket.pug
+++ b/layout/includes/third-party/chat/knocket.pug
@@ -8,22 +8,33 @@ script.
       const isChatBtn = !{theme.chat.rightside_button}
       const isChatHideShow = !{theme.chat.button_hide_show}
 
-      const getWidget = () => document.querySelector('#knocket-widget, [id*="knocket"]')
+      const getWidget = () => document.getElementById('contact-widget-auto')
 
       if (isChatBtn) {
         const hide = () => { const w = getWidget(); if (w) w.style.display = 'none' }
         const show = () => { const w = getWidget(); if (w) w.style.display = '' }
 
+        // Hide the native Knocket floating button
+        const observer = new MutationObserver(() => {
+          if (getWidget()) { hide(); observer.disconnect() }
+        })
+        observer.observe(document.body, { childList: true, subtree: true })
         hide()
 
         window.chatBtnFn = () => {
           const w = getWidget()
-          if (w && w.style.display === 'none') show()
+          if (!w) return
+          if (w.style.display === 'none') show()
           else hide()
         }
 
         document.getElementById('chat-btn').style.display = 'block'
       } else if (isChatHideShow) {
+        const observer = new MutationObserver(() => {
+          if (getWidget()) observer.disconnect()
+        })
+        observer.observe(document.body, { childList: true, subtree: true })
+
         window.chatBtn = {
           hide: () => { const w = getWidget(); if (w) w.style.display = 'none' },
           show: () => { const w = getWidget(); if (w) w.style.display = '' }

--- a/scripts/common/default_config.js
+++ b/scripts/common/default_config.js
@@ -394,6 +394,9 @@ module.exports = {
   crisp: {
     website_id: null
   },
+  knocket: {
+    identifier: null
+  },
   google_tag_manager: {
     tag_id: null,
     domain: 'https://www.googletagmanager.com'


### PR DESCRIPTION
This adds **Knocket** as a new option for the existing `chat.use` setting, next to Chatra, Tidio and Crisp.

Knocket is a 100% free live chat widget that integrates with a single `<script>` tag — a good fit for indie developers and bloggers who want live chat without per-seat pricing.

### Changes
- New partial `layout/includes/third-party/chat/knocket.pug`
- Register `knocket` in the `chat.use` dispatcher (`layout/includes/third-party/chat/index.pug`)
- Add a `knocket:` config block and update the `chat.use` comment in `_config.yml`

### Behaviour
- **Disabled by default.** The widget only renders when both `chat.use: knocket` and `knocket.identifier` are set — zero impact on existing sites.
- Single async `<script>`, no extra JS, no blocking.

### Config example
```yaml
chat:
  use: knocket

knocket:
  identifier: YOUR_ID   # get it from https://trtc.io/solutions/knocket
```

More info: https://trtc.io/solutions/knocket