### PR TITLE
fix: preserve self-closing images in native lazyload

### DIFF
--- a/scripts/filters/post_lazyload.js
+++ b/scripts/filters/post_lazyload.js
@@ -12,7 +12,7 @@ const lazyload = htmlContent => {
   if (hexo.theme.config.lazyload.native) {
     // Use more precise replacement: only replace img tags in HTML, not content inside script tags
     return htmlContent.replace(/(<img(?![^>]*?\bloading=)(?:\s[^>]*?)?>)(?![^<]*<\/script>)/gi, match => {
-      return match.replace(/>$/, ' loading=\'lazy\'>')
+      return match.replace(/(\s*\/?)>$/, (_, closing) => ` loading='lazy'${closing}>`)
     })
   }
 


### PR DESCRIPTION
## Problem

When native lazy loading is enabled, the current replacement appends the `loading` attribute immediately before the final `>`. For self-closing image tags, this produces invalid markup:

`<img src="cover.jpg" />` -> `<img src="cover.jpg" / loading='lazy'>`

This can affect content rendered by Markdown engines or plugins that emit XHTML-style image tags.

## Fix

Preserve the optional whitespace and self-closing slash while inserting `loading='lazy'`.

The change keeps the existing behavior for regular image tags, images with an explicit `loading` attribute, and image-like text inside script tags.

## Testing

- `node --check scripts/filters/post_lazyload.js`
- `git diff --check`
- Verified regular, spaced self-closing, compact self-closing, explicit-loading, and script-tag cases with a Node assertion script
